### PR TITLE
Fix remote participant endpoint publishing

### DIFF
--- a/apps/docs/src/content/docs/guides/hackathon.md
+++ b/apps/docs/src/content/docs/guides/hackathon.md
@@ -56,6 +56,8 @@ gambiarra join --code XK7P2M \
   --nickname carol
 ```
 
+If the hub is running on a different machine, Gambiarra will automatically rewrite `localhost` endpoints to a LAN-reachable URL before publishing them to the hub. If your setup needs a custom published URL, pass `--network-endpoint`.
+
 ### Step 4: Use from Your App
 
 Now everyone can use the shared LLMs:

--- a/apps/docs/src/content/docs/guides/quickstart.mdx
+++ b/apps/docs/src/content/docs/guides/quickstart.mdx
@@ -147,7 +147,9 @@ gambiarra join --code ABC123 --model mistral --endpoint http://localhost:1234
 gambiarra join --code ABC123 --model llama3 --endpoint http://localhost:8000
 ```
 
-The CLI will probe your endpoint, detect available models and protocol capabilities, and register you in the room. It also shares your machine specs (CPU, RAM, GPU) automatically — use `--no-specs` if you prefer not to share.
+The CLI will probe your local endpoint, detect available models and protocol capabilities, and register you in the room. If you join a remote hub from another machine while using `localhost`, Gambiarra automatically tries to publish a LAN-reachable URL instead. Use `--network-endpoint` only when you need to override that published URL manually.
+
+It also shares your machine specs (CPU, RAM, GPU) automatically — use `--no-specs` if you prefer not to share.
 
 Once joined, your LLM is available to everyone in the room.
 

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -160,15 +160,19 @@ gambiarra join --code <room-code> --model <model> [options]
 |--------|-------------|---------|
 | `--code`, `-c` | Room code to join | Required (prompted in interactive mode) |
 | `--model`, `-m` | Model to expose | Required (prompted in interactive mode) |
-| `--endpoint`, `-e` | LLM endpoint URL | `http://localhost:11434` |
+| `--endpoint`, `-e` | Local LLM endpoint URL used for probing and inference | `http://localhost:11434` |
+| `--network-endpoint` | Network-reachable URL to publish to the hub | Auto-detected when needed |
 | `--nickname`, `-n` | Display name | Auto-generated |
 | `--header` | Auth header in the format `Header=Value` | None |
 | `--header-env` | Auth header in the format `Header=ENV_VAR` | None |
 | `--password`, `-p` | Room password (if protected) | None |
 | `--hub`, `-H` | Hub URL | `http://localhost:3000` |
 | `--no-specs` | Don't share machine specs | `false` |
+| `--no-network-rewrite` | Disable automatic localhost-to-LAN rewrite for remote hubs | `false` |
 
-The CLI automatically probes your endpoint to detect available models and protocol capabilities (Responses API vs Chat Completions).
+The CLI automatically probes your local endpoint to detect available models and protocol capabilities (Responses API vs Chat Completions).
+
+When the hub is remote and your local endpoint is loopback-only (for example `http://localhost:11434`), Gambiarra tries to publish a LAN-reachable URL automatically. In interactive mode, the CLI explains the rewrite and lets you confirm or override it. Use `--network-endpoint` when you want to publish a specific URL yourself.
 
 In interactive mode, you'll select your LLM provider from a list (Ollama, LM Studio, vLLM, or custom URL), optionally add auth headers, and then choose from the detected models.
 
@@ -185,6 +189,13 @@ gambiarra join --code ABC123 --model llama3
 gambiarra join --code ABC123 \
   --model mistral \
   --endpoint http://localhost:1234
+
+# Join a remote hub and publish an explicit LAN URL
+gambiarra join --code ABC123 \
+  --hub http://192.168.1.10:3000 \
+  --model llama3 \
+  --endpoint http://localhost:11434 \
+  --network-endpoint http://192.168.1.25:11434
 
 # Join with custom nickname
 gambiarra join --code ABC123 \

--- a/apps/docs/src/content/docs/troubleshooting/common-issues.md
+++ b/apps/docs/src/content/docs/troubleshooting/common-issues.md
@@ -45,6 +45,11 @@ description: Troubleshooting common problems with Gambiarra
    ping hub-ip
    ```
 
+4. **Participant published `localhost` to a remote hub** - `localhost` only works on the participant machine itself.
+   - Let Gambiarra auto-rewrite it in interactive mode
+   - Or pass `--network-endpoint http://<participant-lan-ip>:11434`
+   - Use `--no-network-rewrite` only if you intentionally want to opt out
+
 ## mDNS Discovery Not Working
 
 **Symptoms:**

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -15,8 +15,15 @@ import type {
   RuntimeConfig,
 } from "@gambiarra/core/types";
 import { HEALTH_CHECK_INTERVAL } from "@gambiarra/core/types";
-import { Command, Option } from "../utils/option.ts";
 import { nanoid } from "nanoid";
+import { Command, Option } from "../utils/option.ts";
+import {
+  isLoopbackLikeHost,
+  isRemoteHubUrl,
+  listNetworkCandidates,
+  rankNetworkCandidatesForHub,
+  replaceEndpointHost,
+} from "../utils/network-endpoint.ts";
 import { handleCancel, isInteractive, LLM_PROVIDERS } from "../utils/prompt.ts";
 import {
   hasRuntimeConfig,
@@ -39,16 +46,40 @@ interface JoinResponse {
   roomId: string;
 }
 
-interface JoinInputs {
+interface JoinDraftInputs {
   authHeaders: ParticipantAuthHeaders;
   code: string;
-  model: string;
-  endpoint: string;
-  nickname: string | undefined;
-  password: string | undefined;
-  noSpecs: boolean;
-  capabilities: ParticipantCapabilities;
   config: RuntimeConfig;
+  localEndpoint: string;
+  model: string;
+  networkEndpoint: string | undefined;
+  nickname: string | undefined;
+  noNetworkRewrite: boolean;
+  noSpecs: boolean;
+  password: string | undefined;
+}
+
+interface JoinInputs {
+  authHeaders: ParticipantAuthHeaders;
+  capabilities: ParticipantCapabilities;
+  code: string;
+  config: RuntimeConfig;
+  localEndpoint: string;
+  model: string;
+  nickname: string | undefined;
+  noSpecs: boolean;
+  password: string | undefined;
+  publishedEndpoint: string;
+}
+
+interface ResolvePublishedEndpointParams {
+  hubUrl: string;
+  interactive: boolean;
+  localEndpoint: string;
+  networkEndpoint: string | undefined;
+  noNetworkRewrite: boolean;
+  stderr: NodeJS.WritableStream;
+  stdout: NodeJS.WritableStream;
 }
 
 function parseHeaderAssignment(input: string): { name: string; value: string } {
@@ -95,6 +126,39 @@ function resolveAuthHeaders(
   return authHeaders;
 }
 
+function getEndpointHost(endpoint: string): string {
+  return new URL(endpoint).hostname;
+}
+
+function getRankedPublishedEndpoints(
+  hubUrl: string,
+  localEndpoint: string
+): string[] {
+  const rankedCandidates = rankNetworkCandidatesForHub(
+    hubUrl,
+    listNetworkCandidates()
+  );
+  const publishedEndpoints = rankedCandidates.map((candidate) =>
+    replaceEndpointHost(localEndpoint, candidate.address)
+  );
+
+  return [...new Set(publishedEndpoints)];
+}
+
+function writeRemoteLoopbackExplanation(
+  stdout: NodeJS.WritableStream,
+  hubUrl: string,
+  localEndpoint: string
+): void {
+  stdout.write("\n");
+  stdout.write("Remote hub detected with a loopback endpoint.\n");
+  stdout.write(`  Hub URL: ${hubUrl}\n`);
+  stdout.write(`  Local endpoint: ${localEndpoint}\n`);
+  stdout.write(
+    "  localhost only works on your own machine, so the hub needs a network-reachable URL.\n\n"
+  );
+}
+
 async function promptAuthHeaders(): Promise<ParticipantAuthHeaders> {
   const shouldAddHeaders = await confirm({
     message: "Does this endpoint require auth headers?",
@@ -137,9 +201,9 @@ async function promptEndpoint(currentEndpoint: string): Promise<string> {
   }
 
   const providerOptions = [
-    ...LLM_PROVIDERS.map((p) => ({
-      value: `http://localhost:${p.port}`,
-      label: `${p.name} (localhost:${p.port})`,
+    ...LLM_PROVIDERS.map((provider) => ({
+      value: `http://localhost:${provider.port}`,
+      label: `${provider.name} (localhost:${provider.port})`,
     })),
     { value: "custom", label: "Custom URL" },
   ];
@@ -154,7 +218,7 @@ async function promptEndpoint(currentEndpoint: string): Promise<string> {
     const urlResult = await text({
       message: "Endpoint URL:",
       placeholder: "http://localhost:11434",
-      validate: (v) => (v ? undefined : "Endpoint URL is required"),
+      validate: (value) => (value ? undefined : "Endpoint URL is required"),
     });
     handleCancel(urlResult);
     return urlResult as string;
@@ -186,11 +250,149 @@ async function promptModels(
 
   const modelResult = await select({
     message: "Select model:",
-    options: probe.models.map((m) => ({ value: m, label: m })),
+    options: probe.models.map((model) => ({ value: model, label: model })),
   });
   handleCancel(modelResult);
 
   return { model: modelResult as string, probe };
+}
+
+async function promptManualPublishedEndpoint(
+  localEndpoint: string
+): Promise<string> {
+  const manualEndpointResult = await text({
+    message: "Published network endpoint:",
+    placeholder: replaceEndpointHost(localEndpoint, "192.168.1.50"),
+    validate: (value) => {
+      if (!value?.trim()) {
+        return "Published endpoint is required";
+      }
+
+      try {
+        new URL(value);
+        return undefined;
+      } catch {
+        return "Enter a valid URL";
+      }
+    },
+  });
+  handleCancel(manualEndpointResult);
+  return (manualEndpointResult as string).trim();
+}
+
+async function resolvePublishedEndpoint(
+  params: ResolvePublishedEndpointParams
+): Promise<string | null> {
+  const {
+    hubUrl,
+    interactive,
+    localEndpoint,
+    networkEndpoint,
+    noNetworkRewrite,
+    stderr,
+    stdout,
+  } = params;
+
+  try {
+    new URL(localEndpoint);
+  } catch {
+    stderr.write(`Invalid endpoint URL: ${localEndpoint}\n`);
+    return null;
+  }
+
+  if (networkEndpoint) {
+    try {
+      const normalizedNetworkEndpoint = new URL(networkEndpoint).toString();
+      stdout.write(
+        `Using manually published network endpoint: ${normalizedNetworkEndpoint}\n`
+      );
+      return normalizedNetworkEndpoint;
+    } catch {
+      stderr.write(`Invalid --network-endpoint URL: ${networkEndpoint}\n`);
+      return null;
+    }
+  }
+
+  if (noNetworkRewrite || !isRemoteHubUrl(hubUrl)) {
+    return localEndpoint;
+  }
+
+  if (!isLoopbackLikeHost(getEndpointHost(localEndpoint))) {
+    return localEndpoint;
+  }
+
+  const rankedPublishedEndpoints = getRankedPublishedEndpoints(
+    hubUrl,
+    localEndpoint
+  );
+
+  if (!interactive) {
+    if (rankedPublishedEndpoints.length === 1) {
+      const publishedEndpoint = rankedPublishedEndpoints[0];
+      if (!publishedEndpoint) {
+        return null;
+      }
+      stdout.write(
+        `Remote hub detected. Publishing ${publishedEndpoint} instead of ${localEndpoint}.\n`
+      );
+      return publishedEndpoint;
+    }
+
+    if (rankedPublishedEndpoints.length === 0) {
+      stderr.write(
+        "Remote hub detected, but no LAN IP could be inferred for your local endpoint.\n"
+      );
+      stderr.write(
+        "Pass --network-endpoint with the URL that the hub can reach, or use --no-network-rewrite to opt out.\n"
+      );
+      return null;
+    }
+
+    stderr.write(
+      "Remote hub detected and multiple LAN endpoints are possible for your machine:\n"
+    );
+    for (const candidate of rankedPublishedEndpoints) {
+      stderr.write(`  - ${candidate}\n`);
+    }
+    stderr.write(
+      "Pass --network-endpoint to choose one explicitly, or use interactive mode to select it.\n"
+    );
+    return null;
+  }
+
+  writeRemoteLoopbackExplanation(stdout, hubUrl, localEndpoint);
+
+  const options = rankedPublishedEndpoints.map((publishedEndpoint, index) => ({
+    value: publishedEndpoint,
+    label:
+      index === 0
+        ? `Use ${publishedEndpoint} (Recommended)`
+        : `Use ${publishedEndpoint}`,
+  }));
+
+  options.push(
+    { value: "__manual__", label: "Enter network endpoint manually" },
+    { value: "__keep__", label: `Keep ${localEndpoint}` }
+  );
+
+  const selectedEndpoint = await select({
+    message: "How should this endpoint be published to the hub?",
+    options,
+  });
+  handleCancel(selectedEndpoint);
+
+  if (selectedEndpoint === "__manual__") {
+    return await promptManualPublishedEndpoint(localEndpoint);
+  }
+
+  if (selectedEndpoint === "__keep__") {
+    stdout.write(
+      "Keeping the current endpoint. A remote hub may reject this loopback URL.\n"
+    );
+    return localEndpoint;
+  }
+
+  return selectedEndpoint as string;
 }
 
 async function collectInteractiveInputs(
@@ -198,35 +400,39 @@ async function collectInteractiveInputs(
     authHeaders: ParticipantAuthHeaders;
     code: string | undefined;
     config: RuntimeConfig;
+    hubUrl: string;
+    localEndpoint: string;
     model: string | undefined;
-    endpoint: string;
+    networkEndpoint: string | undefined;
     nickname: string | undefined;
-    password: string | undefined;
+    noNetworkRewrite: boolean;
     noSpecs: boolean;
+    password: string | undefined;
   },
+  stdout: NodeJS.WritableStream,
   stderr: NodeJS.WritableStream
 ): Promise<JoinInputs | null> {
   intro("gambiarra join");
 
-  let { authHeaders, code, model, endpoint, nickname, password, noSpecs } =
+  let { authHeaders, code, localEndpoint, model, nickname, password, noSpecs } =
     defaults;
 
   if (!code) {
     const codeResult = await text({
       message: "Room code:",
-      validate: (v) => (v ? undefined : "Room code is required"),
+      validate: (value) => (value ? undefined : "Room code is required"),
     });
     handleCancel(codeResult);
     code = codeResult as string;
   }
 
-  endpoint = await promptEndpoint(endpoint);
+  localEndpoint = await promptEndpoint(localEndpoint);
   authHeaders = await promptAuthHeaders();
 
   let capabilities: ParticipantCapabilities | undefined;
 
   if (!model) {
-    const result = await promptModels(endpoint, authHeaders, stderr);
+    const result = await promptModels(localEndpoint, authHeaders, stderr);
     if (!result) {
       return null;
     }
@@ -240,9 +446,9 @@ async function collectInteractiveInputs(
       placeholder: `${model}@${nanoid().slice(0, 6)}`,
     });
     handleCancel(nicknameResult);
-    const nick = nicknameResult as string;
-    if (nick) {
-      nickname = nick;
+    const resolvedNickname = (nicknameResult as string).trim();
+    if (resolvedNickname) {
+      nickname = resolvedNickname;
     }
   }
 
@@ -251,9 +457,9 @@ async function collectInteractiveInputs(
       message: "Room password (leave empty if none):",
     });
     handleCancel(passwordResult);
-    const pwd = passwordResult as string;
-    if (pwd) {
-      password = pwd;
+    const resolvedPassword = (passwordResult as string).trim();
+    if (resolvedPassword) {
+      password = resolvedPassword;
     }
   }
 
@@ -267,8 +473,21 @@ async function collectInteractiveInputs(
   }
 
   if (!capabilities) {
-    const probe = await probeEndpoint(endpoint, { authHeaders });
+    const probe = await probeEndpoint(localEndpoint, { authHeaders });
     capabilities = probe.capabilities;
+  }
+
+  const publishedEndpoint = await resolvePublishedEndpoint({
+    hubUrl: defaults.hubUrl,
+    interactive: true,
+    localEndpoint,
+    networkEndpoint: defaults.networkEndpoint,
+    noNetworkRewrite: defaults.noNetworkRewrite,
+    stderr,
+    stdout,
+  });
+  if (!publishedEndpoint) {
+    return null;
   }
 
   let config: RuntimeConfig;
@@ -281,14 +500,15 @@ async function collectInteractiveInputs(
 
   return {
     authHeaders,
-    config,
-    code,
-    model,
-    endpoint,
-    nickname,
-    password,
-    noSpecs,
     capabilities,
+    code,
+    config,
+    localEndpoint,
+    model,
+    nickname,
+    noSpecs,
+    password,
+    publishedEndpoint,
   };
 }
 
@@ -312,6 +532,10 @@ export class JoinCommand extends Command {
         "gambiarra join --code ABC123 --model llama3 --endpoint http://localhost:11434 --nickname 'My GPU'",
       ],
       [
+        "Join a remote hub with an explicit published endpoint",
+        "gambiarra join --code ABC123 --hub http://192.168.1.10:3000 --model llama3 --network-endpoint http://192.168.1.25:11434",
+      ],
+      [
         "Join password-protected room",
         "gambiarra join --code ABC123 --model llama3 --password secret123",
       ],
@@ -329,7 +553,12 @@ export class JoinCommand extends Command {
   });
 
   endpoint = Option.String("--endpoint,-e", "http://localhost:11434", {
-    description: "LLM endpoint URL (OpenResponses or chat/completions capable)",
+    description: "Local LLM endpoint URL used for probing and inference",
+  });
+
+  networkEndpoint = Option.String("--network-endpoint", {
+    description: "Network-reachable URL to publish to the hub",
+    required: false,
   });
 
   nickname = Option.String("--nickname,-n", {
@@ -362,6 +591,11 @@ export class JoinCommand extends Command {
     description: "Don't share machine specs (CPU, RAM, GPU)",
   });
 
+  noNetworkRewrite = Option.Boolean("--no-network-rewrite", false, {
+    description:
+      "Disable automatic localhost-to-LAN endpoint rewrite for remote hubs",
+  });
+
   private async loadConfig(): Promise<RuntimeConfig | null> {
     if (!this.configPath) {
       return {};
@@ -375,10 +609,7 @@ export class JoinCommand extends Command {
     }
   }
 
-  private async resolveInputs(): Promise<Omit<
-    JoinInputs,
-    "capabilities"
-  > | null> {
+  private async resolveInputs(): Promise<JoinDraftInputs | null> {
     if (this.code && this.model) {
       let authHeaders: ParticipantAuthHeaders;
       try {
@@ -397,13 +628,16 @@ export class JoinCommand extends Command {
         authHeaders,
         code: this.code,
         config,
+        localEndpoint: this.endpoint,
         model: this.model,
-        endpoint: this.endpoint,
+        networkEndpoint: this.networkEndpoint,
         nickname: this.nickname,
-        password: this.password,
+        noNetworkRewrite: this.noNetworkRewrite,
         noSpecs: this.noSpecs,
+        password: this.password,
       };
     }
+
     if (!this.code) {
       this.context.stderr.write(
         "Error: --code is required (or run in a terminal for interactive mode)\n"
@@ -425,12 +659,27 @@ export class JoinCommand extends Command {
       if (!resolved) {
         return null;
       }
+
+      const publishedEndpoint = await resolvePublishedEndpoint({
+        hubUrl: this.hub,
+        interactive: false,
+        localEndpoint: resolved.localEndpoint,
+        networkEndpoint: resolved.networkEndpoint,
+        noNetworkRewrite: resolved.noNetworkRewrite,
+        stderr: this.context.stderr,
+        stdout: this.context.stdout,
+      });
+      if (!publishedEndpoint) {
+        return null;
+      }
+
       return {
         ...resolved,
         capabilities: {
           openResponses: "unknown",
           chatCompletions: "unknown",
         },
+        publishedEndpoint,
       };
     }
 
@@ -441,60 +690,56 @@ export class JoinCommand extends Command {
 
     return collectInteractiveInputs(
       {
-        code: this.code,
-        model: this.model,
         authHeaders: {},
+        code: this.code,
         config,
-        endpoint: this.endpoint,
+        hubUrl: this.hub,
+        localEndpoint: this.endpoint,
+        model: this.model,
+        networkEndpoint: this.networkEndpoint,
         nickname: this.nickname,
-        password: this.password,
+        noNetworkRewrite: this.noNetworkRewrite,
         noSpecs: this.noSpecs,
+        password: this.password,
       },
+      this.context.stdout,
       this.context.stderr
     );
   }
 
   private async executeInteractiveJoin(inputs: JoinInputs): Promise<number> {
-    const {
-      authHeaders,
-      config,
-      code,
-      model,
-      endpoint,
-      nickname,
-      password,
-      noSpecs,
-      capabilities,
-    } = inputs;
-
-    const specs = noSpecs ? { cpu: "Hidden", ram: 0 } : await detectSpecs();
+    const specs = inputs.noSpecs
+      ? { cpu: "Hidden", ram: 0 }
+      : await detectSpecs();
     const participantId = nanoid();
-    const finalNickname = nickname ?? `${model}@${participantId.slice(0, 6)}`;
+    const finalNickname =
+      inputs.nickname ?? `${inputs.model}@${participantId.slice(0, 6)}`;
 
     return this.registerAndListen({
-      code,
-      config,
-      model,
-      endpoint,
-      authHeaders,
-      password,
-      participantId,
+      authHeaders: inputs.authHeaders,
+      capabilities: inputs.capabilities,
+      code: inputs.code,
+      config: inputs.config,
       finalNickname,
-      specs,
-      capabilities,
       interactive: true,
+      localEndpoint: inputs.localEndpoint,
+      model: inputs.model,
+      participantId,
+      password: inputs.password,
+      publishedEndpoint: inputs.publishedEndpoint,
+      specs,
     });
   }
 
   private async executeNonInteractiveJoin(inputs: JoinInputs): Promise<number> {
     const [probe, specs] = await Promise.all([
-      probeEndpoint(inputs.endpoint, { authHeaders: inputs.authHeaders }),
+      probeEndpoint(inputs.localEndpoint, { authHeaders: inputs.authHeaders }),
       inputs.noSpecs
         ? Promise.resolve({ cpu: "Hidden" as const, ram: 0 })
         : detectSpecs(),
     ]);
 
-    if (!this.validateProbe(probe, inputs.endpoint, inputs.model)) {
+    if (!this.validateProbe(probe, inputs.localEndpoint, inputs.model)) {
       return 1;
     }
 
@@ -507,17 +752,18 @@ export class JoinCommand extends Command {
       inputs.nickname ?? `${inputs.model}@${participantId.slice(0, 6)}`;
 
     return this.registerAndListen({
+      authHeaders: inputs.authHeaders,
+      capabilities: probe.capabilities,
       code: inputs.code,
       config: inputs.config,
-      model: inputs.model,
-      endpoint: inputs.endpoint,
-      authHeaders: inputs.authHeaders,
-      password: inputs.password,
-      participantId,
       finalNickname,
-      specs,
-      capabilities: probe.capabilities,
       interactive: false,
+      localEndpoint: inputs.localEndpoint,
+      model: inputs.model,
+      participantId,
+      password: inputs.password,
+      publishedEndpoint: inputs.publishedEndpoint,
+      specs,
     });
   }
 
@@ -558,30 +804,32 @@ export class JoinCommand extends Command {
   }
 
   private async registerAndListen(opts: {
+    authHeaders: ParticipantAuthHeaders;
+    capabilities: ParticipantCapabilities;
     code: string;
     config: RuntimeConfig;
-    model: string;
-    endpoint: string;
-    authHeaders: ParticipantAuthHeaders;
-    password: string | undefined;
-    participantId: string;
     finalNickname: string;
-    specs: { cpu: string; ram: number; gpu?: string };
-    capabilities: ParticipantCapabilities;
     interactive: boolean;
+    localEndpoint: string;
+    model: string;
+    participantId: string;
+    password: string | undefined;
+    publishedEndpoint: string;
+    specs: { cpu: string; ram: number; gpu?: string };
   }): Promise<number> {
     const {
+      authHeaders,
+      capabilities,
       code,
       config,
-      model,
-      endpoint,
-      authHeaders,
-      password,
-      participantId,
       finalNickname,
-      specs,
-      capabilities,
       interactive,
+      localEndpoint,
+      model,
+      participantId,
+      password,
+      publishedEndpoint,
+      specs,
     } = opts;
 
     try {
@@ -589,7 +837,7 @@ export class JoinCommand extends Command {
         id: participantId,
         nickname: finalNickname,
         model,
-        endpoint,
+        endpoint: publishedEndpoint,
         specs,
         config,
         capabilities,
@@ -626,7 +874,8 @@ export class JoinCommand extends Command {
         `  Participant ID: ${data.participant.id}`,
         `  Nickname: ${data.participant.nickname}`,
         `  Model: ${data.participant.model}`,
-        `  Endpoint: ${data.participant.endpoint}`,
+        `  Local endpoint: ${localEndpoint}`,
+        `  Published endpoint: ${data.participant.endpoint}`,
         "",
         "Your endpoint is now available through the hub.",
         "Press Ctrl+C to leave the room.",
@@ -637,13 +886,12 @@ export class JoinCommand extends Command {
       } else {
         this.context.stdout.write(`${successMsg}\n\n`);
       }
-    } catch (err) {
+    } catch (error) {
       this.context.stderr.write(`Failed to connect to hub at ${this.hub}\n`);
-      this.context.stderr.write(`${err}\n`);
+      this.context.stderr.write(`${error}\n`);
       return 1;
     }
 
-    // Start health check loop
     const healthInterval = setInterval(async () => {
       try {
         const response = await fetch(`${this.hub}/rooms/${code}/health`, {
@@ -664,7 +912,6 @@ export class JoinCommand extends Command {
       }
     }, HEALTH_CHECK_INTERVAL);
 
-    // Handle graceful shutdown
     const cleanup = async () => {
       this.context.stdout.write("\nLeaving room...\n");
       clearInterval(healthInterval);
@@ -684,7 +931,6 @@ export class JoinCommand extends Command {
     process.on("SIGINT", cleanup);
     process.on("SIGTERM", cleanup);
 
-    // Keep the process running
     await new Promise(() => undefined);
     return 0;
   }

--- a/packages/cli/src/utils/network-endpoint.test.ts
+++ b/packages/cli/src/utils/network-endpoint.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isLoopbackLikeHost,
+  isRemoteHubUrl,
+  rankNetworkCandidatesForHub,
+  replaceEndpointHost,
+} from "./network-endpoint.ts";
+
+describe("network endpoint helpers", () => {
+  test("detects loopback-like hosts", () => {
+    expect(isLoopbackLikeHost("localhost")).toBe(true);
+    expect(isLoopbackLikeHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackLikeHost("0.0.0.0")).toBe(true);
+    expect(isLoopbackLikeHost("192.168.1.25")).toBe(false);
+  });
+
+  test("distinguishes local and remote hubs", () => {
+    expect(isRemoteHubUrl("http://localhost:3000")).toBe(false);
+    expect(isRemoteHubUrl("http://127.0.0.1:3000")).toBe(false);
+    expect(isRemoteHubUrl("http://192.168.1.10:3000")).toBe(true);
+  });
+
+  test("prioritizes candidates on the same /24 subnet as the hub", () => {
+    const ranked = rankNetworkCandidatesForHub("http://192.168.1.10:3000", [
+      { address: "10.0.0.25", interfaceName: "en1" },
+      { address: "192.168.1.25", interfaceName: "en0" },
+      { address: "192.168.2.30", interfaceName: "en2" },
+    ]);
+
+    expect(ranked).toEqual([
+      { address: "192.168.1.25", interfaceName: "en0" },
+    ]);
+  });
+
+  test("replaces only the endpoint host", () => {
+    expect(
+      replaceEndpointHost("http://localhost:11434/v1/models", "192.168.1.25")
+    ).toBe("http://192.168.1.25:11434/v1/models");
+  });
+});

--- a/packages/cli/src/utils/network-endpoint.ts
+++ b/packages/cli/src/utils/network-endpoint.ts
@@ -1,0 +1,136 @@
+import { networkInterfaces } from "node:os";
+
+export interface NetworkCandidate {
+  address: string;
+  interfaceName: string;
+}
+
+const IPV4_FAMILY = "IPv4";
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const UNSPECIFIED_HOSTS = new Set(["0.0.0.0", "::"]);
+
+function getIpv4Octets(address: string): number[] | null {
+  const segments = address.split(".");
+  if (segments.length !== 4) {
+    return null;
+  }
+
+  const octets = segments.map((segment) => Number(segment));
+  return octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255)
+    ? octets
+    : null;
+}
+
+function isLinkLocalIpv4(address: string): boolean {
+  const octets = getIpv4Octets(address);
+  return octets !== null && octets[0] === 169 && octets[1] === 254;
+}
+
+function isPrivateIpv4(address: string): boolean {
+  const octets = getIpv4Octets(address);
+  if (octets === null) {
+    return false;
+  }
+
+  const first = octets[0];
+  const second = octets[1];
+  if (first === undefined || second === undefined) {
+    return false;
+  }
+
+  return (
+    first === 10 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function isSameSubnet24(left: string, right: string): boolean {
+  const leftOctets = getIpv4Octets(left);
+  const rightOctets = getIpv4Octets(right);
+  if (!(leftOctets && rightOctets)) {
+    return false;
+  }
+
+  return (
+    leftOctets[0] === rightOctets[0] &&
+    leftOctets[1] === rightOctets[1] &&
+    leftOctets[2] === rightOctets[2]
+  );
+}
+
+export function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname.toLowerCase());
+}
+
+export function isUnspecifiedHost(hostname: string): boolean {
+  return UNSPECIFIED_HOSTS.has(hostname.toLowerCase());
+}
+
+export function isLoopbackLikeHost(hostname: string): boolean {
+  return isLoopbackHost(hostname) || isUnspecifiedHost(hostname);
+}
+
+export function isRemoteHubUrl(hubUrl: string): boolean {
+  const { hostname } = new URL(hubUrl);
+  return !isLoopbackLikeHost(hostname);
+}
+
+export function listNetworkCandidates(): NetworkCandidate[] {
+  const candidates: NetworkCandidate[] = [];
+  const interfaces = networkInterfaces();
+
+  for (const [interfaceName, entries] of Object.entries(interfaces)) {
+    if (!entries) {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (
+        entry.family !== IPV4_FAMILY ||
+        entry.internal ||
+        isLinkLocalIpv4(entry.address)
+      ) {
+        continue;
+      }
+
+      candidates.push({
+        interfaceName,
+        address: entry.address,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+export function rankNetworkCandidatesForHub(
+  hubUrl: string,
+  candidates: NetworkCandidate[]
+): NetworkCandidate[] {
+  const { hostname } = new URL(hubUrl);
+
+  const sameSubnet = candidates.filter((candidate) =>
+    isSameSubnet24(candidate.address, hostname)
+  );
+  if (sameSubnet.length > 0) {
+    return sameSubnet;
+  }
+
+  if (isPrivateIpv4(hostname)) {
+    const privateCandidates = candidates.filter((candidate) =>
+      isPrivateIpv4(candidate.address)
+    );
+    if (privateCandidates.length > 0) {
+      return privateCandidates;
+    }
+  }
+
+  return candidates;
+}
+
+export function replaceEndpointHost(endpoint: string, hostname: string): string {
+  const url = new URL(endpoint);
+  url.hostname = hostname;
+  return url.toString();
+}

--- a/packages/core/src/hub.test.ts
+++ b/packages/core/src/hub.test.ts
@@ -484,11 +484,15 @@ describe("Hub", () => {
         openResponses: "supported" | "unsupported" | "unknown";
         chatCompletions: "supported" | "unsupported" | "unknown";
       };
-    }
+    },
+    headers?: Record<string, string>
   ) {
     const res = await fetch(`${baseUrl}/rooms/${code}/join`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
       body: JSON.stringify(participant),
     });
     return { res, data: await res.json() };
@@ -613,6 +617,25 @@ describe("Hub", () => {
 
       expect(res.status).toBe(400);
       expect(data.error).toContain("Missing required fields");
+    });
+
+    test("rejects loopback endpoints when the participant joins remotely", async () => {
+      const { room } = await createRoom("Remote Room");
+      const { res, data } = await joinRoom(
+        room.code,
+        {
+          id: "participant-remote",
+          nickname: "remote-user",
+          model: "llama3",
+          endpoint: "http://localhost:11434",
+        },
+        { "x-forwarded-for": "192.168.1.50" }
+      );
+
+      expect(res.status).toBe(400);
+      const errorData = ErrorResponseSchema.parse(data);
+      expect(errorData.error).toContain("only reachable on the participant machine");
+      expect(errorData.error).toContain("--network-endpoint");
     });
 
     test("redacts participant instructions in join and list responses", async () => {

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -51,8 +51,11 @@ const RESPONSES_PATH_REGEX =
 const TRAILING_SLASH_REGEX = /\/$/;
 const SSE_LINE_SPLIT_REGEX = /\r?\n/;
 const SSE_EVENT_SEPARATOR = "\n\n";
+const FORWARDED_IP_SEPARATOR_REGEX = /,/;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const UNSPECIFIED_HOSTS = new Set(["0.0.0.0", "::"]);
 
 interface AccumulatedToolCall {
   arguments: string;
@@ -115,6 +118,55 @@ function getDefaultCapabilities(): ParticipantInfoInternal["capabilities"] {
 
 function normalizeEndpoint(endpoint: string): string {
   return endpoint.replace(TRAILING_SLASH_REGEX, "");
+}
+
+function isLoopbackLikeHost(hostname: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  return (
+    LOOPBACK_HOSTS.has(normalizedHostname) ||
+    UNSPECIFIED_HOSTS.has(normalizedHostname)
+  );
+}
+
+function isLoopbackRequesterIp(address: string): boolean {
+  return (
+    address === "::1" ||
+    address === "127.0.0.1" ||
+    address.startsWith("127.") ||
+    address === "::ffff:127.0.0.1" ||
+    address.startsWith("::ffff:127.")
+  );
+}
+
+function getRequesterIp(
+  req: Request,
+  server?: { requestIP: (req: Request) => { address: string } | null }
+): string | null {
+  const forwarded = req.headers
+    .get("x-forwarded-for")
+    ?.split(FORWARDED_IP_SEPARATOR_REGEX)[0]
+    ?.trim();
+  if (forwarded) {
+    return forwarded;
+  }
+
+  return server?.requestIP(req)?.address ?? null;
+}
+
+function getRemoteLoopbackJoinError(
+  requesterIp: string | null,
+  endpoint: string
+): string | null {
+  if (!(requesterIp && !isLoopbackRequesterIp(requesterIp))) {
+    return null;
+  }
+
+  const hostname = new URL(endpoint).hostname;
+  if (!isLoopbackLikeHost(hostname)) {
+    return null;
+  }
+
+  return `Endpoint '${endpoint}' is only reachable on the participant machine. You joined from ${requesterIp}, so publish a network-reachable URL instead (for example via '--network-endpoint').`;
 }
 
 function participantUrl(
@@ -334,7 +386,11 @@ function listRooms(): Response {
   return json({ rooms: Room.listWithParticipantCount() });
 }
 
-async function joinRoom(req: Request, code: string): Promise<Response> {
+async function joinRoom(
+  req: Request,
+  code: string,
+  requesterIp: string | null
+): Promise<Response> {
   const room = Room.getByCode(code);
   if (!room) {
     return error("Room not found", 404);
@@ -360,6 +416,13 @@ async function joinRoom(req: Request, code: string): Promise<Response> {
   }
 
   const body = parsedBody.data;
+  const remoteLoopbackJoinError = getRemoteLoopbackJoinError(
+    requesterIp,
+    body.endpoint
+  );
+  if (remoteLoopbackJoinError) {
+    return error(remoteLoopbackJoinError, 400);
+  }
 
   // Validate password if room is protected
   const isPasswordValid = await Room.validatePassword(
@@ -1542,9 +1605,21 @@ async function proxyResponsesCreate(
   } catch (proxyError) {
     SSE.broadcast(
       "llm:error",
-      { participantId: participant.id, error: String(proxyError) },
+      {
+        participantId: participant.id,
+        nickname: participant.nickname,
+        endpoint: participant.endpoint,
+        model: body.model,
+        error: String(proxyError),
+      },
       code
     );
+    console.error("[gambiarra] responses proxy failed", {
+      participantId: participant.id,
+      nickname: participant.nickname,
+      endpoint: participant.endpoint,
+      error: String(proxyError),
+    });
     return error(`Failed to proxy request: ${proxyError}`, 502);
   }
 }
@@ -1580,9 +1655,21 @@ async function proxyChatCompletions(
   } catch (proxyError) {
     SSE.broadcast(
       "llm:error",
-      { participantId: participant.id, error: String(proxyError) },
+      {
+        participantId: participant.id,
+        nickname: participant.nickname,
+        endpoint: participant.endpoint,
+        model: body.model,
+        error: String(proxyError),
+      },
       code
     );
+    console.error("[gambiarra] chat proxy failed", {
+      participantId: participant.id,
+      nickname: participant.nickname,
+      endpoint: participant.endpoint,
+      error: String(proxyError),
+    });
     return error(`Failed to proxy request: ${proxyError}`, 502);
   }
 }
@@ -1717,10 +1804,11 @@ function handleRoomRoute(
   req: Request,
   method: string,
   path: string,
-  code: string
+  code: string,
+  requesterIp: string | null
 ): Promise<Response> | Response | null {
   if (path === `/rooms/${code}/join` && method === "POST") {
-    return joinRoom(req, code);
+    return joinRoom(req, code, requesterIp);
   }
 
   if (LEAVE_PATH_REGEX.test(path) && method === "DELETE") {
@@ -1808,7 +1896,14 @@ export function createHub(options: HubOptions = {}): Hub {
 
       const roomMatch = path.match(ROOM_PATH_REGEX);
       if (roomMatch?.[1]) {
-        const result = handleRoomRoute(req, method, path, roomMatch[1]);
+        const requesterIp = getRequesterIp(req, server);
+        const result = handleRoomRoute(
+          req,
+          method,
+          path,
+          roomMatch[1],
+          requesterIp
+        );
         if (result) {
           return result;
         }


### PR DESCRIPTION
## Context
At the event, remote participants were able to join the room and appear in the arena, but generation never reached their machines. Presence worked because the hub accepted the join, while inference failed because some participants effectively published loopback-only endpoints such as `http://localhost:11434`.

That case still works on the same machine as the hub, which is why the local self-join test streamed correctly, but it is not reachable from the hub when the participant is on another computer.

## What changed
### CLI join flow
- keep `--endpoint` as the local probe endpoint on the participant machine
- add automatic LAN endpoint publishing when `--hub` is remote and the local endpoint is loopback-like
- add interactive guidance to confirm or override the detected network endpoint
- add `--network-endpoint` as the advanced manual override
- add `--no-network-rewrite` as the explicit opt-out
- print both the local endpoint and the published endpoint on successful join

### Hub validation and errors
- reject remote joins that still advertise a loopback or unspecified endpoint
- keep same-machine localhost joins valid
- enrich proxy failure logging and SSE error events with participant id, nickname, endpoint, model, and network error details

### Docs
- update the CLI reference with the local-vs-published endpoint model and the new flags
- update quickstart and hackathon docs with the remote-hub behavior
- add troubleshooting guidance for the silent "joined but never generated" failure mode

## Testing
- `bun run check-types`
- `bun test packages/cli/src/utils/network-endpoint.test.ts`
- `bun test packages/core/src/hub.test.ts packages/sdk/src/client.test.ts`
- `bun test`
  - still reports one failure in `packages/core/src/endpoint-capabilities.test.ts` (`probeEndpoint > does not detect protected endpoints without auth headers`), which is outside the code touched in this PR
