### PR TITLE
fix: harden npm cli packaging

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "astro dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gambi",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "description": "CLI for Gambi - Share local LLMs across your network",
   "keywords": [
     "llm",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@gambi/config",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "private": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gambi/core",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "type": "module",
   "exports": {
     "./types": "./src/types.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gambi-sdk",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "description": "Share local LLMs across your network, effortlessly",
   "keywords": [
     "llm",


### PR DESCRIPTION
## Summary
- publish the CLI as a bundled npm artifact instead of raw source with workspace dependencies
- inject the package version into the built CLI and harden the release workflow so CLI publishes always build the correct artifact
- keep package version bumps out of this PR so the release workflow remains the source of truth for versioning

## Impact
- makes the `gambi` npm tarball valid for release, instead of publishing `src/cli.ts` plus `workspace:*` metadata
- preserves the current runtime model: the npm-installed CLI still expects `bun` on the user machine, because the published entrypoint is a Bun bundle with `#!/usr/bin/env bun`
- prevents the release workflow from regressing back to the broken publish shape on the next CLI release
- does not yet implement the more robust `opencode`-style wrapper package with per-platform binaries and `optionalDependencies`

## Validation
- bun run --cwd packages/cli check-types
- bun run --cwd packages/cli build
- npm pack --dry-run --cache /tmp/npm-cache (packages/cli)
- bun run --cwd packages/sdk build
- npm pack --dry-run --cache /tmp/npm-cache (packages/sdk)
