### PR TITLE
feat(sdk): add gambi-sdk/discovery subpath export

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Example config JSON:
 
 ```typescript
 import { createGambi, resolveGambiTarget } from "gambi-sdk";
+// Discovery also available as: import { resolveGambiTarget } from "gambi-sdk/discovery"
 import { generateText } from "ai";
 
 const target = await resolveGambiTarget({

--- a/apps/docs/src/content/docs/guides/ai-tools.md
+++ b/apps/docs/src/content/docs/guides/ai-tools.md
@@ -156,6 +156,7 @@ For local Node.js or Bun applications, you can also discover the hub and room fi
 
 ```typescript
 import { createGambi, resolveGambiTarget } from "gambi-sdk";
+// or: import { resolveGambiTarget } from "gambi-sdk/discovery";
 
 const target = await resolveGambiTarget({
   roomCode: "ABC123", // optional if only one room is visible

--- a/apps/docs/src/content/docs/reference/sdk.md
+++ b/apps/docs/src/content/docs/reference/sdk.md
@@ -21,6 +21,7 @@ These helpers are optional. `createGambi()` and `createClient()` stay explicit a
 
 ```typescript
 import { createClient, createGambi, resolveGambiTarget } from "gambi-sdk";
+// or import only discovery: import { resolveGambiTarget } from "gambi-sdk/discovery";
 
 const target = await resolveGambiTarget({
   roomCode: "ABC123", // optional if exactly one room is available

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,8 @@ For local Node.js/Bun applications, the SDK also exposes optional discovery help
 - `discoverRooms()` - aggregate rooms across reachable hubs
 - `resolveGambiTarget()` - resolve one room to `{ hubUrl, roomCode }`
 
+These helpers are available from the root export (`gambi-sdk`) or from the dedicated subpath `gambi-sdk/discovery` for a smaller import surface.
+
 These helpers are additive. `createGambi()` and `createClient()` remain explicit and do not perform implicit async discovery.
 
 ### `gambi-tui`

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -125,7 +125,7 @@ For local Node.js or Bun applications, you can resolve a room first and keep the
 
 ```typescript
 import { createGambi, resolveGambiTarget } from "gambi-sdk";
-// or import only discovery (smaller import, no AI SDK peer dep needed):
+// or import only discovery (smaller import, no AI SDK needed at runtime):
 // import { resolveGambiTarget } from "gambi-sdk/discovery";
 
 const target = await resolveGambiTarget({

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -125,6 +125,8 @@ For local Node.js or Bun applications, you can resolve a room first and keep the
 
 ```typescript
 import { createGambi, resolveGambiTarget } from "gambi-sdk";
+// or import only discovery (smaller import, no AI SDK peer dep needed):
+// import { resolveGambiTarget } from "gambi-sdk/discovery";
 
 const target = await resolveGambiTarget({
   roomCode: "ABC123",
@@ -136,7 +138,7 @@ const gambi = createGambi({
 });
 ```
 
-The SDK also exposes `discoverHubs()` and `discoverRooms()` if you want to build your own room picker UI.
+The SDK also exposes `discoverHubs()` and `discoverRooms()` if you want to build your own room picker UI. All discovery functions are available from the root export or from `gambi-sdk/discovery`.
 
 ## API Reference
 

--- a/packages/sdk/build.ts
+++ b/packages/sdk/build.ts
@@ -10,20 +10,20 @@ console.log("✓ Cleaned dist/");
 // O client é re-exportado pelo index, então não precisa de entrypoint separado
 const entrypoints = ["./src/index.ts"];
 
-// 3. Build com bun (gera .js)
+const sharedOptions = {
+  target: "node" as const,
+  format: "esm" as const,
+  sourcemap: "external" as const,
+  minify: false,
+  external: ["ai", "@ai-sdk/provider"],
+};
+
+// 3. Build principal com bun (gera .js)
 const result = await build({
   entrypoints,
   outdir: "./dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  minify: false,
   splitting: true, // Funciona bem com poucos entrypoints
-  external: [
-    // Peer dependencies não devem ser bundladas
-    "ai",
-    "@ai-sdk/provider",
-  ],
+  ...sharedOptions,
 });
 
 if (!result.success) {
@@ -33,8 +33,25 @@ if (!result.success) {
 
 console.log(`✓ Built ${result.outputs.length} files`);
 
-// 4. Gerar .d.ts files com tsc
-await $`bun tsc --emitDeclarationOnly --outDir dist`;
+// 4. Build separado para subpath export gambi-sdk/discovery
+// Não pode ser adicionado como segundo entrypoint ao build principal
+// porque o index re-exporta discovery, o que aciona o bug de duplicate exports do bun
+const discoveryResult = await build({
+  entrypoints: ["./src/discovery.ts"],
+  outdir: "./dist",
+  splitting: false,
+  ...sharedOptions,
+});
+
+if (!discoveryResult.success) {
+  console.error("✗ Discovery subpath build failed");
+  process.exit(1);
+}
+
+console.log(`✓ Built discovery subpath (${discoveryResult.outputs.length} files)`);
+
+// 5. Gerar .d.ts files com tsc
+await $`bun tsc --emitDeclarationOnly --outDir dist --noEmit false`;
 console.log("✓ Generated type declarations");
 
 console.log("✓ Build completed successfully");

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -55,6 +55,11 @@
     "ai": "^4 || ^5 || ^6",
     "typescript": "^5"
   },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.1",
     "@gambi/core": "workspace:*",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,6 +31,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./discovery": {
+      "types": "./dist/discovery.d.ts",
+      "default": "./dist/discovery.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Add `gambi-sdk/discovery` subpath export so consumers can import discovery functions without pulling in the full SDK bundle and its AI SDK peer dependency
- Build discovery as a separate Bun build step (workaround for Bun's duplicate exports bug with multiple entrypoints)
- Fix tsc declaration generation (`--noEmit false` override needed due to tsconfig's `noEmit: true`)
- Update docs across 5 files with new import path examples

Closes #35

## Test plan

- [x] `bun run --cwd packages/sdk check-types` passes
- [x] `bun run --cwd packages/sdk build` passes (includes subpath file verification)
- [x] `bun test packages/sdk/src` — 42 tests pass
- [x] `npm pack --dry-run` confirms `discovery.js` and `discovery.d.ts` in tarball


🤖 Generated with [Claude Code](https://claude.com/claude-code)