### PR TITLE
Redesign CLI, SDK, and hub around agent-first management APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - Guia Operacional para Agentes de Código
 
 Escopo: este arquivo orienta agentes que iniciam trabalho no repositório `gambi`.
-Status de validação: conteúdo conferido no código em 2026-03-18.
+Status de validação: conteúdo conferido no código em 2026-04-05.
 
 ## 1) Objetivo do projeto
 
@@ -44,16 +44,22 @@ Arquivos de referência rápida:
 ## 4) Contratos e comportamentos críticos
 
 Endpoints do hub (HTTP):
-- `POST /rooms`
-- `GET /rooms`
-- `POST /rooms/:code/join`
-- `DELETE /rooms/:code/leave/:id`
-- `POST /rooms/:code/health`
-- `GET /rooms/:code/participants`
+- `GET /v1/health`
+- `GET /v1/rooms`
+- `POST /v1/rooms`
+- `GET /v1/rooms/:code`
+- `GET /v1/rooms/:code/participants`
+- `PUT /v1/rooms/:code/participants/:id`
+- `DELETE /v1/rooms/:code/participants/:id`
+- `POST /v1/rooms/:code/participants/:id/heartbeat`
+- `GET /v1/rooms/:code/events` (SSE)
 - `GET /rooms/:code/v1/models`
 - `POST /rooms/:code/v1/chat/completions`
-- `GET /rooms/:code/events` (SSE)
-- `GET /health`
+- `POST /rooms/:code/v1/responses`
+- `GET /rooms/:code/v1/responses/:id`
+- `DELETE /rooms/:code/v1/responses/:id`
+- `POST /rooms/:code/v1/responses/:id/cancel`
+- `GET /rooms/:code/v1/responses/:id/input_items`
 
 Roteamento de modelo no proxy:
 - `model = <participant-id>`: participante específico.
@@ -67,11 +73,28 @@ Health e disponibilidade:
 
 Comportamento do CLI:
 - `gambi` sem argumentos exibe help com referencia ao `gambi-tui`.
-- Subcomandos registrados hoje: `serve`, `create`, `join`, `list`, `update`.
-- Todos os comandos suportam modo interativo: quando rodados sem flags obrigatorias em TTY, promptam o usuario via `@clack/prompts`.
-- Flags continuam funcionando normalmente para scripting e automacao.
-- `gambi update` atualiza instalacoes via `bun`, `npm` ou binario standalone do instalador oficial.
-- No modo interativo do `join`, o usuario seleciona provedor LLM (Ollama, LM Studio, vLLM ou custom) e modelo de uma lista.
+- Comandos operacionais atuais:
+  - `gambi hub serve`
+  - `gambi room create|list|get`
+  - `gambi participant join|leave|heartbeat`
+  - `gambi events watch`
+  - `gambi self update`
+- O CLI e orientado a recursos e a automacao por flags.
+- Saida estruturada:
+  - `--format text|json|ndjson`
+  - stdout pipeado escolhe `json` ou `ndjson` por padrao
+- Controles de interatividade:
+  - `--interactive`
+  - `--no-interactive`
+  - `GAMBI_NO_INTERACTIVE=1`
+- `gambi self update` atualiza instalacoes via `bun`, `npm` ou binario standalone do instalador oficial.
+- `gambi participant join` exige `--participant-id` para fluxos nao interativos retry-safe.
+
+Contratos operacionais:
+- O management plane em `/v1` e a superficie canonica para automacao.
+- SDK de operacao deve mapear diretamente para os contratos do core.
+- O CLI deve renderizar sobre contratos estruturados do core, sem inventar contratos textuais paralelos.
+- Compatibilidade retroativa nao e um requisito padrao quando houver pedido explicito de clean break, como neste redesign.
 
 ## 5) Setup e comandos oficiais
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ Obrigatorio:
 - Nao executar comandos destrutivos sem solicitacao explicita.
 - Nao assumir arvore limpa.
 - Se detectar mudancas inesperadas novas durante a tarefa, pausar e reportar.
+- Usar **Conventional Commits** em todo novo commit (`tipo(escopo): resumo`), por exemplo `fix(cli): tratar cancelamento em prompts`.
 
 ## 10) Inconsistencias conhecidas (documentar, nao ignorar)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,13 +107,22 @@ Comandos na raiz:
 ```bash
 bun run dev
 bun run dev:hub
+bun run dev:cli -- --help
+bun run dev:cli -- room list --format json
 bun run dev:tui
+bun run dev:monitor
 bun run dev:docs
 bun run build
 bun run check-types
 bun x ultracite check
 bun x ultracite fix
 ```
+
+Fluxo de dev na raiz:
+- `bun run dev` e `bun run dev:hub` iniciam o hub com `gambi hub serve`.
+- `bun run dev:cli -- <subcomando...>` e o entrypoint padrao para testar qualquer subcomando do CLI a partir da raiz.
+- `bun run dev:monitor` aponta para a TUI; nao existe mais comando plano `monitor` no CLI.
+- Nao reintroduzir scripts raiz com comandos removidos como `serve`, `create`, `join`, `list`, `update` ou `monitor` sem namespace de recurso.
 
 Comandos por workspace:
 ```bash
@@ -122,6 +131,7 @@ bun run --cwd packages/core check-types
 
 # CLI
 bun run --cwd packages/cli dev
+bun run --cwd packages/cli dev -- --help
 bun run --cwd packages/cli build
 bun run --cwd packages/cli check-types
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ As NDJSON for scripts:
 gambi events watch --room ABC123 --format ndjson
 ```
 
+Room event streams include lifecycle signals such as `llm.request`, `llm.complete`, and `llm.error`.
+
 ### 5. Use the SDK for inference
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -358,9 +358,20 @@ Sensitive config is redacted from public management responses. Public room and p
 ```bash
 bun install
 bun run dev
+bun run dev:hub
+bun run dev:cli -- --help
+bun run dev:cli -- room list --format json
+bun run dev:cli -- hub serve --dry-run --format json
 bun run build
 bun run check-types
 ```
+
+Root dev workflow:
+
+- `bun run dev` and `bun run dev:hub` start the hub with `gambi hub serve`
+- `bun run dev:cli -- <subcommand...>` forwards any CLI command from the repo root
+- `bun run dev:monitor` is a TUI alias for human-first monitoring
+- Prefer `bun run dev:cli -- room create --help` and `bun run dev:cli -- participant join --help` for CLI discovery during development
 
 Workspace-specific:
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ gambi hub serve
 Machine-readable dry run:
 
 ```bash
-gambi hub serve --dry-run --format json
+gambi hub serve --dry-run --format ndjson
 ```
 
 ### 2. Create a room
@@ -124,7 +124,7 @@ gambi participant join \
   --participant-id worker-1 \
   --model llama3 \
   --dry-run \
-  --format json
+  --format ndjson
 ```
 
 ### 4. Watch room events
@@ -353,6 +353,8 @@ Rooms and participants can both provide runtime defaults. The hub merges them at
 
 Sensitive config is redacted from public management responses. Public room and participant payloads expose safe summaries instead of raw secrets or instructions.
 
+Streaming commands always emit NDJSON for machine-readable output. If you pass `--format json` to a streaming command, the CLI coerces it to `ndjson`.
+
 ## Development
 
 ```bash
@@ -361,7 +363,7 @@ bun run dev
 bun run dev:hub
 bun run dev:cli -- --help
 bun run dev:cli -- room list --format json
-bun run dev:cli -- hub serve --dry-run --format json
+bun run dev:cli -- hub serve --dry-run --format ndjson
 bun run build
 bun run check-types
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <div align="center">
 
-**Share local LLMs across your network, effortlessly.**
+**Share local LLMs across your network, with an agent-friendly control plane.**
 
 [![npm version](https://img.shields.io/npm/v/gambi-sdk)](https://www.npmjs.com/package/gambi-sdk)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
@@ -19,740 +19,358 @@
 
 </div>
 
----
-
-## Table of Contents
-
-- [What is Gambi?](#-what-is-gambi)
-- [Installation](#-installation)
-  - [CLI](#cli)
-  - [SDK](#sdk)
-- [Quick Start](#-quick-start)
-- [Features](#-features)
-- [Usage Examples](#-usage-examples)
-- [Architecture](#-architecture)
-- [Development](#-development)
-- [Supported Providers](#-supported-providers)
-- [Security](#-security-considerations)
-- [Roadmap](#-roadmap)
-- [Contributing](#-contributing)
-- [License](#-license)
-
----
-
 ## What is Gambi?
 
-**Gambi** is a local-first LLM sharing system that allows multiple users on a network to pool their LLM resources together. Everyone can share their Ollama, LM Studio, LocalAI, or any endpoint that speaks OpenResponses or OpenAI-compatible chat/completions.
+Gambi is a local-first system for sharing OpenAI-compatible LLM endpoints across a trusted network. A central hub tracks rooms and participants, proxies inference requests, and publishes real-time events over SSE.
 
-The public name **Gambi** is the short form of **gambiarra**. In Brazilian Portuguese, **gambiarra** here means the good kind: creative improvisation under constraints—resourceful, community-minded problem solving, not a sloppy hack. The shorter spelling is easier to say, type, and wire into CLI commands and package names in English, without losing that meaning.
+The public name **Gambi** is the short form of **gambiarra**. Here it means the good kind: creative improvisation under constraints, turned into a practical tool.
 
-If you installed the project under its previous CLI package name, see the [migration guide](https://gambi.sh/guides/migrate-from-gambiarra/).
+## Two planes
 
-### Upgrading from a legacy global install
+Gambi exposes two distinct surfaces:
 
-If you still have the old global CLI package installed, remove it and install **Gambi**:
+- Management plane: native Gambi HTTP endpoints under `/v1`, plus the operational CLI and SDK management client.
+- Inference plane: OpenAI-compatible room-scoped endpoints under `/rooms/:code/v1/*`, consumed by `createGambi()` and other OpenAI-compatible clients.
 
-```bash
-# npm
-npm uninstall -g gambiarra && npm install -g gambi
-
-# bun
-bun remove -g gambiarra && bun add -g gambi
-```
-
-```typescript
-import { createGambi } from "gambi-sdk";
-
-const gambi = createGambi({ roomCode: "ABC123" });
-```
-
-### Why Gambi?
-
-- **Local-First**: Your data stays on your network
-- **Resource Sharing**: Pool LLM endpoints across your team
-- **OpenResponses First**: Prefers `v1/responses` by default and falls back to `chat/completions` when needed
-- **Universal Compatibility**: Works with OpenResponses and OpenAI-compatible chat/completions APIs
-- **Vercel AI SDK Integration**: Drop-in replacement for your AI SDK workflows
-- **Auto-Discovery**: mDNS/Bonjour support for zero-config networking
-- **Real-time Monitoring**: Beautiful TUI for tracking room activity
-- **Production Ready**: Built with TypeScript, Bun, and modern tooling
-
-### Use Cases
-
-- **Development Teams**: Share expensive LLM endpoints across your team
-- **Hackathons**: Pool resources for AI projects
-- **Research Labs**: Coordinate LLM access across multiple workstations
-- **Home Labs**: Share your gaming PC's LLM with your laptop
-- **Education**: Classroom environments where students share compute
-
----
+That split is deliberate. The management plane is optimized for agents and automation. The inference plane is optimized for application compatibility.
 
 ## Installation
 
 ### CLI
 
-The CLI allows you to start hubs, create rooms, join as a participant, and update the installed package.
-
-**Linux / macOS (recommended - standalone binary):**
+Linux / macOS:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/arthurbm/gambi/main/scripts/install.sh | bash
 ```
 
-**Windows (PowerShell):**
+Windows:
 
 ```powershell
 irm https://raw.githubusercontent.com/arthurbm/gambi/main/scripts/install.ps1 | iex
 ```
 
-**Via npm (first-class wrapper package):**
+npm / bun:
 
 ```bash
 npm install -g gambi
-```
-
-The published `gambi` package installs a lightweight wrapper plus the matching platform binary for the current machine. It does not require Bun at runtime.
-
-**Via bun:**
-
-```bash
+# or
 bun add -g gambi
 ```
 
-`bun add -g gambi` installs the same wrapper package and matching platform binary.
-
-**Verify installation:**
+Verify:
 
 ```bash
 gambi --version
 ```
 
-**Update to the latest installed version:**
-
-```bash
-gambi update
-```
-
-`gambi update` supports Bun/npm global installs and the official standalone installer paths.
-
-**Uninstall:**
-
-```bash
-# Linux / macOS (standalone binary)
-curl -fsSL https://raw.githubusercontent.com/arthurbm/gambi/main/scripts/uninstall.sh | bash
-```
-
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/arthurbm/gambi/main/scripts/uninstall.ps1 | iex
-```
-
-```bash
-# If installed via npm
-npm uninstall -g gambi
-
-# If installed via bun
-bun remove -g gambi
-```
-
 ### SDK
-
-The SDK provides Vercel AI SDK integration for using shared LLMs in your applications.
-
-**Via npm:**
 
 ```bash
 npm install gambi-sdk
-```
-
-**Via bun:**
-
-```bash
+# or
 bun add gambi-sdk
-```
-
-**Uninstall:**
-
-```bash
-# If installed via npm
-npm uninstall gambi-sdk
-
-# If installed via bun
-bun remove gambi-sdk
 ```
 
 ### TUI
 
-Interactive terminal dashboard for monitoring and managing rooms in real-time. Requires [Bun](https://bun.sh).
+`gambi-tui` is the human-first monitoring interface. It is separate from the CLI.
 
 ```bash
 bun add -g gambi-tui
 ```
 
-**Usage:**
+## Quick start
+
+### 1. Start the hub
 
 ```bash
-gambi-tui                                    # Connect to localhost:3000
-gambi-tui --hub http://192.168.1.100:3000    # Connect to remote hub
+gambi hub serve
 ```
 
----
-
-## Quick Start
-
-### 1. Start the Hub Server
+Machine-readable dry run:
 
 ```bash
-gambi serve
-# Or with flags: gambi serve --port 3000 --mdns
+gambi hub serve --dry-run --format json
 ```
 
-### 2. Create a Room
+### 2. Create a room
 
 ```bash
-gambi create
-# Or with flags: gambi create --name "My Room" --config ./room-defaults.json
+gambi room create --name "Demo"
 ```
 
-### 3. Join with Your LLM
+With room defaults from JSON:
 
 ```bash
-gambi join
-# Or with flags: gambi join --code ABC123 --model llama3 --config ./participant-config.json
+gambi room create --name "Demo" --config ./room-defaults.json
 ```
 
-All commands support **interactive mode** — run without flags and you'll be guided through each option step by step. Flags still work for scripting and automation.
+### 3. Register a participant
 
-Example config JSON:
-
-```json
-{
-  "instructions": "Always answer in Brazilian Portuguese.",
-  "temperature": 0.4,
-  "max_tokens": 512
-}
+```bash
+gambi participant join \
+  --room ABC123 \
+  --participant-id worker-1 \
+  --model llama3 \
+  --endpoint http://localhost:11434
 ```
 
-### 4. Use the SDK
+Preview the registration flow:
 
-```typescript
+```bash
+gambi participant join \
+  --room ABC123 \
+  --participant-id worker-1 \
+  --model llama3 \
+  --dry-run \
+  --format json
+```
+
+### 4. Watch room events
+
+```bash
+gambi events watch --room ABC123
+```
+
+As NDJSON for scripts:
+
+```bash
+gambi events watch --room ABC123 --format ndjson
+```
+
+### 5. Use the SDK for inference
+
+```ts
+import { createGambi } from "gambi-sdk";
+import { generateText } from "ai";
+
+const gambi = createGambi({
+  roomCode: "ABC123",
+  hubUrl: "http://localhost:3000",
+});
+
+const result = await generateText({
+  model: gambi.any(),
+  prompt: "Explain how SSE works.",
+});
+
+console.log(result.text);
+```
+
+### 6. Resolve a room dynamically with `resolveGambiTarget()`
+
+```ts
 import { createGambi, resolveGambiTarget } from "gambi-sdk";
-// Discovery also available as: import { resolveGambiTarget } from "gambi-sdk/discovery"
 import { generateText } from "ai";
 
 const target = await resolveGambiTarget({
-  roomCode: "ABC123", // optional if only one room is visible on your LAN
+  roomCode: "ABC123",
+  timeoutMs: 1500,
 });
 
 const gambi = createGambi({
-  roomCode: target.roomCode,
   hubUrl: target.hubUrl,
+  roomCode: target.roomCode,
 });
 
 const result = await generateText({
   model: gambi.any(),
-  prompt: "Hello, Gambi!",
+  prompt: "Hello from a discovered room.",
 });
-
-console.log(result.text);
 ```
 
-For scripts or hosted environments where discovery is not needed, you can still pass `hubUrl` and `roomCode` directly.
+Use this when your app is running on a local network and you want to resolve the hub and room before creating the provider. For fixed deployments, you can keep passing `hubUrl` and `roomCode` directly.
 
----
+### 7. Use the SDK for management
 
-## Features
+```ts
+import { createClient } from "gambi-sdk";
 
-### CLI Interface
+const client = createClient({ hubUrl: "http://localhost:3000" });
+
+const created = await client.rooms.create({ name: "Ops" });
+console.log(created.data.room.code);
+
+const participants = await client.participants.list(created.data.room.code);
+console.log(participants.data.length);
+```
+
+## CLI overview
+
+The CLI is resource-oriented:
 
 ```bash
-# All commands support interactive mode — just run the command:
-gambi serve
-gambi create
-gambi join
-gambi list
-gambi update
-
-# Or use flags for scripting:
-gambi serve --mdns
-gambi create --name "My Room" --config ./room-defaults.json
-gambi join --code ABC123 --model llama3 --config ./participant-config.json
-gambi list --json
-gambi update --dry-run
+gambi hub serve
+gambi room create
+gambi room list
+gambi room get
+gambi participant join
+gambi participant leave
+gambi participant heartbeat
+gambi events watch
+gambi self update
 ```
 
-Room defaults are merged at request time with precedence `room defaults -> participant defaults -> runtime request`. Public room/participant listings expose only a safe summary such as `hasInstructions`, not the raw instructions text.
+Agent-first behavior:
 
-### Runtime Defaults
+- `--format text|json|ndjson` on the operational commands
+- `--interactive` and `--no-interactive`
+- default `json` or `ndjson` when stdout is piped
+- XDG config at `~/.config/gambi/config.json`
+- `--config -` for stdin-driven JSON on commands that accept runtime config
 
-Use runtime defaults when you want a room or participant to contribute reusable behavior without forcing every client request to repeat the same settings.
-
-Example room defaults:
+Example config:
 
 ```json
 {
-  "instructions": "Answer in Brazilian Portuguese.",
-  "temperature": 0.3,
-  "max_tokens": 512
+  "defaultEnv": "local",
+  "envs": {
+    "local": {
+      "hubUrl": "http://localhost:3000",
+      "endpoint": "http://localhost:11434"
+    },
+    "staging": {
+      "hubUrl": "http://192.168.1.10:3000",
+      "networkEndpoint": "http://192.168.1.25:11434"
+    }
+  }
 }
 ```
 
-Create a room with defaults:
+## SDK overview
 
-```bash
-gambi create --name "Portuguese Room" --config ./room-defaults.json
+Use `createGambi()` when your application wants inference through the OpenAI-compatible room endpoints:
+
+```ts
+const gambi = createGambi({ roomCode: "ABC123" });
+
+gambi.any();
+gambi.participant("worker-1");
+gambi.model("llama3");
+gambi.openResponses.any();
+gambi.chatCompletions.any();
 ```
 
-Example participant defaults:
+Use `resolveGambiTarget()` when the room or hub should be discovered from the local network first:
+
+```ts
+import { createGambi, resolveGambiTarget } from "gambi-sdk";
+
+const target = await resolveGambiTarget({
+  roomCode: "ABC123",
+});
+
+const gambi = createGambi(target);
+```
+
+The SDK also exposes `discoverHubs()` and `discoverRooms()` for lower-level discovery workflows.
+
+Use `createClient()` when your application needs operational control:
+
+```ts
+const client = createClient({ hubUrl: "http://localhost:3000" });
+
+await client.rooms.list();
+await client.rooms.get("ABC123");
+await client.participants.upsert("ABC123", "worker-1", {
+  nickname: "worker-1",
+  model: "llama3",
+  endpoint: "http://192.168.1.25:11434",
+});
+await client.participants.heartbeat("ABC123", "worker-1");
+await client.participants.remove("ABC123", "worker-1");
+```
+
+Room event watching:
+
+```ts
+for await (const event of client.events.watchRoom({ roomCode: "ABC123" })) {
+  console.log(event.type, event.data);
+}
+```
+
+## HTTP API overview
+
+Management API:
+
+- `GET /v1/health`
+- `GET /v1/rooms`
+- `POST /v1/rooms`
+- `GET /v1/rooms/:code`
+- `GET /v1/rooms/:code/participants`
+- `PUT /v1/rooms/:code/participants/:id`
+- `DELETE /v1/rooms/:code/participants/:id`
+- `POST /v1/rooms/:code/participants/:id/heartbeat`
+- `GET /v1/rooms/:code/events`
+
+Inference API:
+
+- `GET /rooms/:code/v1/models`
+- `POST /rooms/:code/v1/responses`
+- `GET /rooms/:code/v1/responses/:id`
+- `DELETE /rooms/:code/v1/responses/:id`
+- `POST /rooms/:code/v1/responses/:id/cancel`
+- `GET /rooms/:code/v1/responses/:id/input_items`
+- `POST /rooms/:code/v1/chat/completions`
+
+Management responses use envelopes:
 
 ```json
 {
-  "instructions": "Prefer concise technical answers.",
-  "temperature": 0.6
+  "data": {
+    "status": "ok",
+    "timestamp": 1743884000000
+  },
+  "meta": {
+    "requestId": "req_123"
+  }
 }
 ```
 
-Join with participant defaults:
+Management errors are structured:
 
-```bash
-gambi join --code ABC123 --model llama3 --config ./participant-config.json
-```
-
-Merge behavior:
-
-- Room defaults apply first.
-- Participant defaults override room defaults.
-- The request sent by the client overrides both.
-
-Public API behavior:
-
-- Sensitive instruction text is stored by the hub but not exposed in public room or participant listings.
-- Public responses expose summary fields such as `hasInstructions` instead.
-
-### SDK Integration
-
-```typescript
-import { createGambi } from "gambi-sdk";
-import { generateText } from "ai";
-
-const gambi = createGambi({ roomCode: "ABC123" });
-
-// Use any available participant
-const result = await generateText({
-  model: gambi.any(),
-  prompt: "Explain quantum computing",
-});
-
-// Target specific participant
-const result2 = await generateText({
-  model: gambi.participant("joao"),
-  prompt: "Write a haiku about TypeScript",
-});
-
-// Route by model type
-const result3 = await generateText({
-  model: gambi.model("llama3"),
-  prompt: "What is the meaning of life?",
-});
-
-// Use Chat Completions instead of the default Responses API
-const legacy = createGambi({
-  roomCode: "ABC123",
-  defaultProtocol: "chatCompletions",
-});
-
-const result4 = await generateText({
-  model: legacy.any(),
-  prompt: "Hello from chat/completions",
-});
-```
-
-### Terminal UI
-
-Monitor rooms in real-time with a beautiful TUI:
-
-```bash
-cd apps/tui
-bun run dev ABC123
-```
-
----
-
-## Usage Examples
-
-### CLI Commands
-
-#### Start a Hub
-
-```bash
-# Interactive — prompts for port, host, mDNS:
-gambi serve
-
-# Or with flags:
-gambi serve --port 3000 --mdns
-```
-
-#### Create a Room
-
-```bash
-# Interactive — prompts for name and password:
-gambi create
-
-# Or with flags:
-gambi create --name "My Room"
-gambi create --name "My Room" --config ./room-defaults.json
-```
-
-#### List Rooms
-
-```bash
-# Interactive — prompts for hub URL and output format:
-gambi list
-
-# Or with flags:
-gambi list --json
-```
-
-#### Join a Room
-
-```bash
-# Interactive — select provider, model, set nickname:
-gambi join
-
-# Or with flags:
-gambi join --code ABC123 --model llama3
-gambi join --code ABC123 --model mistral --endpoint http://localhost:1234
-gambi join --code ABC123 --model llama3 --config ./participant-config.json
-```
-
-#### Update the CLI Package
-
-```bash
-# Detect the installation method and update to the latest release:
-gambi update
-
-# Preview the exact command without executing it:
-gambi update --dry-run
-```
-
-### SDK Examples
-
-#### Basic Chat
-
-```typescript
-import { createGambi } from "gambi-sdk";
-import { generateText } from "ai";
-
-const gambi = createGambi({ roomCode: "ABC123" });
-
-const result = await generateText({
-  model: gambi.any(),
-  prompt: "What is TypeScript?",
-});
-
-console.log(result.text);
-```
-
-#### Streaming
-
-```typescript
-import { createGambi } from "gambi-sdk";
-import { streamText } from "ai";
-
-const gambi = createGambi({ roomCode: "ABC123" });
-
-const stream = await streamText({
-  model: gambi.model("llama3"),
-  prompt: "Write a story about a robot",
-});
-
-for await (const chunk of stream.textStream) {
-  process.stdout.write(chunk);
+```json
+{
+  "error": {
+    "code": "ROOM_NOT_FOUND",
+    "message": "Room 'ABC123' not found.",
+    "hint": "Create the room first or verify the code."
+  },
+  "meta": {
+    "requestId": "req_456"
+  }
 }
 ```
 
-#### With Custom Config
+## Runtime defaults
 
-```typescript
-const gambi = createGambi({
-  roomCode: "ABC123",
-  hubUrl: "http://192.168.1.100:3000",
-});
+Rooms and participants can both provide runtime defaults. The hub merges them at proxy time with this precedence:
 
-const result = await generateText({
-  model: gambi.any(),
-  prompt: "Explain recursion",
-  temperature: 0.7,
-  maxTokens: 500,
-});
-```
+1. room defaults
+2. participant defaults
+3. request-time overrides
 
-### Terminal UI
-
-```bash
-cd apps/tui
-bun install
-bun run dev ABC123
-```
-
-The TUI provides real-time monitoring of:
-- Active participants
-- Current model loads
-- Request history
-- Participant health status
-
----
-
-## Architecture
-
-Gambi uses a **HTTP + SSE architecture** for simplicity and compatibility:
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    GAMBI HUB (HTTP)                     │
-│                                                             │
-│  Endpoints:                                                 │
-│  • POST   /rooms                    (Create room)          │
-│  • GET    /rooms                    (List rooms)           │
-│  • POST   /rooms/:code/join         (Join room)            │
-│  • POST   /rooms/:code/v1/responses (Proxy)               │
-│  • GET    /rooms/:code/v1/responses/:id                   │
-│  • DELETE /rooms/:code/v1/responses/:id                   │
-│  • POST   /rooms/:code/v1/responses/:id/cancel            │
-│  • GET    /rooms/:code/v1/responses/:id/input_items       │
-│  • POST   /rooms/:code/v1/chat/completions (Proxy)        │
-│  • GET    /rooms/:code/events       (SSE updates)          │
-└─────────────────────────────────────────────────────────────┘
-       ▲                    ▲                      ▲
-       │ HTTP               │ HTTP                 │ SSE
-       │                    │                      │
-  ┌────┴────┐    ┌─────────┴────────┐      ┌──────┴─────┐
-  │   SDK   │    │  Participants    │      │    TUI     │
-  └─────────┘    └──────────────────┘      └────────────┘
-```
-
-### Key Components
-
-- **Hub**: Central HTTP server that routes requests and manages rooms
-- **Participants**: LLM endpoints registered in a room (Ollama, LM Studio, etc.)
-- **SDK**: Vercel AI SDK provider that proxies to the hub
-- **TUI**: Real-time monitoring interface using Server-Sent Events
-
-Internally, the hub uses a protocol adapter registry. `OpenResponses` is the default public path, but the core stays open to additional protocol adapters instead of baking protocol-specific branching into every call site.
-
-### Model Routing
-
-| Pattern | Example | Description |
-|---------|---------|-------------|
-| **Participant ID** | `gambi.participant("joao")` | Route to specific participant |
-| **Model Name** | `gambi.model("llama3")` | Route to first participant with model |
-| **Any** | `gambi.any()` | Route to random online participant |
-
-### Project Structure
-
-```
-gambi/
-├── packages/
-│   ├── core/              # Core library (Hub, Room, Protocol)
-│   ├── cli/               # Command-line interface
-│   └── sdk/               # Vercel AI SDK integration
-├── apps/
-│   ├── docs/              # Documentation site (Astro Starlight)
-│   └── tui/               # Terminal UI (published as gambi-tui)
-└── docs/                  # Architecture documentation
-```
-
-### Packages
-
-| Package | Description | Version |
-|---------|-------------|---------|
-| `gambi` | CLI for managing hubs and participants | 0.1.0 |
-| `gambi-sdk` | Vercel AI SDK provider | 0.1.0 |
-| `gambi-tui` | Interactive terminal dashboard | 0.3.1 |
-| `@gambi/core` | Hub server, room management, SSE, mDNS (internal) | 0.0.1 |
-
-For detailed architecture, see [docs/architecture.md](./docs/architecture.md).
-
----
+Sensitive config is redacted from public management responses. Public room and participant payloads expose safe summaries instead of raw secrets or instructions.
 
 ## Development
 
-### Setup
-
 ```bash
-# Clone the repository
-git clone https://github.com/arthurbm/gambi.git
-cd gambi
-
-# Install dependencies
 bun install
-
-# Build all packages
-bun run build
-```
-
-### Commands
-
-```bash
-# Run hub server in development mode
 bun run dev
-
-# Run docs app
-bun run dev:docs
-
-# Type checking
+bun run build
 bun run check-types
-
-# Linting and formatting (Ultracite/Biome)
-bun x ultracite check
-bun x ultracite fix
 ```
 
-### Working with Packages
+Workspace-specific:
 
 ```bash
-# Work on CLI
-cd packages/cli
-bun run dev serve --port 3000
-
-# Work on Core
-cd packages/core
-bun run check-types
-
-# Work on SDK
-cd packages/sdk
-bun run check-types
+bun run --cwd packages/core check-types
+bun run --cwd packages/cli check-types
+bun run --cwd packages/sdk check-types
+bun run --cwd apps/tui test
 ```
 
-### Code Standards
+## Security
 
-This project uses [Ultracite](https://github.com/Kikobeats/ultracite), a zero-config preset for Biome. See [CLAUDE.md](./CLAUDE.md) for detailed code standards.
-
-### Releasing
-
-Releases are automated via GitHub Actions. The workflow updates synchronized versions, publishes the SDK, publishes the CLI binary packages first, publishes the `gambi` wrapper last, and then creates GitHub releases with the same binaries.
-
-**Via GitHub UI:**
-
-1. Go to **Actions** > **Release** > **Run workflow**
-2. Select bump type: `patch`, `minor`, or `major`
-3. Click **Run workflow**
-
-**Via GitHub CLI:**
-
-```bash
-# Release the synchronized package set
-gh workflow run release.yml -f bump=patch
-
-# Watch the workflow progress
-gh run watch
-```
-
-The workflow will:
-- Calculate the new version (e.g., 0.1.1 → 0.1.2 for patch)
-- Pin the release to one source commit
-- Update all `package.json` files
-- Build the CLI distribution once and reuse it across publish and release
-- Publish the CLI binary packages before the `gambi` wrapper
-- Build and publish to npm
-- Commit and tag the release
-- Create a GitHub Release with binaries
-
-For a deeper explanation of the release pipeline and package layout, see:
-
-- [`docs/versioning.md`](./docs/versioning.md)
-- [`docs/release-architecture.md`](./docs/release-architecture.md)
-
----
-
-## Supported Providers
-
-Gambi works with endpoints that expose **OpenResponses** or **OpenAI-compatible chat/completions**:
-
-| Provider | Default Endpoint | Notes |
-|----------|------------------|-------|
-| **Ollama** | `http://localhost:11434` | Most popular local LLM server |
-| **LM Studio** | `http://localhost:1234` | GUI-based LLM management |
-| **LocalAI** | `http://localhost:8080` | Self-hosted OpenAI alternative |
-| **vLLM** | `http://localhost:8000` | High-performance inference |
-| **text-generation-webui** | `http://localhost:5000` | Gradio-based interface |
-| **Custom** | Any URL | Any OpenAI-compatible endpoint |
-
----
-
-## Security Considerations
-
-- **Local Network Only**: Gambi is designed for trusted local networks
-- **No Authentication**: Currently no built-in auth (use network isolation)
-- **HTTP Only**: Uses plain HTTP (consider reverse proxy for HTTPS)
-- **Participant Trust**: All participants can access shared models
-
-For production use, consider:
-- Running behind a reverse proxy (Caddy, Nginx)
-- Using VPN or WireGuard for remote access
-- Implementing authentication at the proxy level
-
----
-
-## Roadmap
-
-- [ ] Authentication & authorization
-- [ ] Participant quotas and rate limiting
-- [ ] Persistent room storage (SQLite/PostgreSQL)
-- [ ] Load balancing across multiple participants
-- [ ] Model capability negotiation
-- [ ] Web UI for room management
-- [ ] Docker/container support
-- [ ] Metrics and observability
-- [ ] Request queueing for busy participants
-
----
-
-## Contributing
-
-Contributions are welcome! This is an early-stage project and we'd love your help.
-
-### How to Contribute
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run `bun x ultracite fix` to format code
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
-
-### Development Guidelines
-
-- Follow the code standards in [CLAUDE.md](./CLAUDE.md)
-- Write type-safe TypeScript
-- Add tests for new features
-- Update documentation as needed
-
----
-
-## License
-
-MIT License - see [LICENSE](./LICENSE) for details.
-
----
-
-## Acknowledgments
-
-Built with:
-- [Bun](https://bun.sh) - Fast JavaScript runtime
-- [Turbo](https://turbo.build) - High-performance build system
-- [Vercel AI SDK](https://sdk.vercel.ai) - AI integration framework
-- [Biome](https://biomejs.dev) - Fast formatter and linter
-- [Clipanion](https://github.com/arcanis/clipanion) - Type-safe CLI framework
-- [Bonjour](https://github.com/onlxltd/bonjour-service) - mDNS service discovery
-
----
-
-<div align="center">
-
-**Made with love for the local LLM community**
-
-[Report Bug](https://github.com/arthurbm/gambi/issues) | [Request Feature](https://github.com/arthurbm/gambi/issues)
-
-</div>
+Gambi is designed for trusted local networks. The hub does not provide built-in authentication. Do not expose it directly to the public internet without an external proxy and auth layer.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -264,6 +264,7 @@ Current event types:
 - `participant.left`
 - `participant.offline`
 - `llm.request`
+- `llm.complete`
 - `llm.error`
 
 Example event:

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -1,307 +1,358 @@
 ---
 title: API Reference
-description: Complete HTTP API reference for the Gambi hub. OpenAI-compatible endpoints for chat completions and responses.
+description: Reference for the Gambi management and inference HTTP APIs.
 ---
 
-The Gambi hub exposes an OpenAI-compatible HTTP API. Any tool or library that works with the OpenAI API can work with Gambi by changing the base URL.
+The Gambi hub exposes two HTTP contracts:
 
-The project was previously published as `gambiarra`. The current public metadata key in `/v1/models` is `gambi`.
+- Management API: native Gambi endpoints under `/v1`
+- Inference API: OpenAI-compatible room-scoped endpoints under `/rooms/:code/v1/*`
 
-## Base URL
+## Base URLs
 
-All LLM endpoints are scoped to a room:
+Management:
 
+```text
+http://<hub-host>:<port>/v1/
 ```
+
+Inference:
+
+```text
 http://<hub-host>:<port>/rooms/<ROOM_CODE>/v1/
 ```
 
-Example: `http://192.168.1.100:3000/rooms/ABC123/v1/`
-
 ## Authentication
 
-No authentication is required. Gambi is designed for trusted local networks. CORS is enabled for all origins.
+The hub does not provide native authentication. It is designed for trusted local networks. CORS is enabled for all origins.
 
-## Model Routing
+## Management API
 
-The `model` field in requests controls which participant handles it:
+### Envelope contract
 
-| Value | Behavior | Example |
-|-------|----------|---------|
-| `*` or `any` | Random online participant | `"model": "*"` |
-| `model:<name>` | First online participant with that model | `"model": "model:llama3"` |
-| `<participant-id>` | Specific participant by ID | `"model": "abc123"` |
-| `<model-name>` | Tries participant ID first, then model match | `"model": "llama3"` |
-
-## LLM Endpoints
-
-### POST /rooms/:code/v1/chat/completions
-
-OpenAI-compatible chat completions proxy. Supports streaming.
-
-**Request:**
+Successful management responses use:
 
 ```json
 {
-  "model": "*",
-  "messages": [
-    { "role": "system", "content": "You are a helpful assistant" },
-    { "role": "user", "content": "Hello!" }
-  ],
-  "stream": false,
-  "temperature": 0.7,
-  "max_tokens": 500
+  "data": {},
+  "meta": {
+    "requestId": "req_123"
+  }
 }
 ```
 
-**curl (non-streaming):**
+Management errors use:
+
+```json
+{
+  "error": {
+    "code": "ROOM_NOT_FOUND",
+    "message": "Room 'ABC123' not found.",
+    "hint": "Create the room first or verify the room code."
+  },
+  "meta": {
+    "requestId": "req_456"
+  }
+}
+```
+
+Common error codes:
+
+- `ROOM_NOT_FOUND`
+- `PARTICIPANT_NOT_FOUND`
+- `INVALID_REQUEST`
+- `INVALID_PASSWORD`
+- `ENDPOINT_NOT_REACHABLE`
+- `LOOPBACK_ENDPOINT_FOR_REMOTE_HUB`
+- `PARTICIPANT_CONFLICT`
+- `MODEL_NOT_FOUND`
+
+### GET /v1/health
+
+Check whether the hub is running.
 
 ```bash
-curl -X POST http://localhost:3000/rooms/ABC123/v1/chat/completions \
+curl http://localhost:3000/v1/health
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "status": "ok",
+    "timestamp": 1743884000000
+  },
+  "meta": {
+    "requestId": "req_123"
+  }
+}
+```
+
+### GET /v1/rooms
+
+List room summaries.
+
+```bash
+curl http://localhost:3000/v1/rooms
+```
+
+Each room summary includes:
+
+- `id`
+- `code`
+- `name`
+- `hostId`
+- `createdAt`
+- `participantCount`
+- `passwordProtected`
+- `defaults`
+
+### POST /v1/rooms
+
+Create a room.
+
+```bash
+curl -X POST http://localhost:3000/v1/rooms \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "*",
-    "messages": [{"role": "user", "content": "Hello!"}]
+    "name": "Demo",
+    "password": "secret",
+    "defaults": {
+      "temperature": 0.4
+    }
   }'
 ```
 
-**curl (streaming):**
+Example response:
+
+```json
+{
+  "data": {
+    "room": {
+      "id": "room_123",
+      "code": "ABC123",
+      "name": "Demo",
+      "hostId": "host_123",
+      "createdAt": 1743884000000,
+      "participantCount": 0,
+      "passwordProtected": true,
+      "defaults": {
+        "temperature": 0.4
+      }
+    },
+    "hostId": "host_123"
+  },
+  "meta": {
+    "requestId": "req_234"
+  }
+}
+```
+
+### GET /v1/rooms/:code
+
+Fetch one room summary by code.
 
 ```bash
-curl -X POST http://localhost:3000/rooms/ABC123/v1/chat/completions \
+curl http://localhost:3000/v1/rooms/ABC123
+```
+
+### GET /v1/rooms/:code/participants
+
+List participants in a room.
+
+```bash
+curl http://localhost:3000/v1/rooms/ABC123/participants
+```
+
+Participant summaries include:
+
+- `id`
+- `nickname`
+- `model`
+- `endpoint`
+- `status`
+- `joinedAt`
+- `updatedAt`
+- `lastSeen`
+- `specs`
+- `config`
+- `capabilities`
+
+### PUT /v1/rooms/:code/participants/:id
+
+Create or update a participant registration.
+
+This endpoint is idempotent and is the canonical registration path.
+
+```bash
+curl -X PUT http://localhost:3000/v1/rooms/ABC123/participants/worker-1 \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "*",
-    "messages": [{"role": "user", "content": "Hello!"}],
-    "stream": true
+    "nickname": "worker-1",
+    "model": "llama3",
+    "endpoint": "http://192.168.1.25:11434",
+    "capabilities": {
+      "openResponses": "supported",
+      "chatCompletions": "supported"
+    }
   }'
 ```
 
-Streaming responses use Server-Sent Events (`data: {...}` chunks, terminated by `data: [DONE]`).
+Behavior:
 
-### POST /rooms/:code/v1/responses
+- `201` when the participant is created
+- `200` when the participant already exists and is updated or unchanged
 
-OpenAI Responses API proxy (primary protocol). Supports streaming.
+### DELETE /v1/rooms/:code/participants/:id
 
-**Request:**
-
-```json
-{
-  "model": "*",
-  "input": "Hello!",
-  "stream": false
-}
-```
-
-**With instructions:**
-
-```json
-{
-  "model": "*",
-  "input": "Translate to Portuguese",
-  "instructions": "You are a translator",
-  "stream": true
-}
-```
-
-**curl:**
+Remove a participant from a room.
 
 ```bash
-curl -X POST http://localhost:3000/rooms/ABC123/v1/responses \
-  -H "Content-Type: application/json" \
-  -d '{"model": "*", "input": "Hello!"}'
+curl -X DELETE http://localhost:3000/v1/rooms/ABC123/participants/worker-1
 ```
+
+### POST /v1/rooms/:code/participants/:id/heartbeat
+
+Send a heartbeat for one participant.
+
+```bash
+curl -X POST http://localhost:3000/v1/rooms/ABC123/participants/worker-1/heartbeat
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "success": true,
+    "status": "online",
+    "lastSeen": 1743884000000
+  },
+  "meta": {
+    "requestId": "req_345"
+  }
+}
+```
+
+Health constants:
+
+- heartbeat interval: `10_000 ms`
+- offline timeout: `30_000 ms`
+
+### GET /v1/rooms/:code/events
+
+Subscribe to room events as SSE.
+
+```bash
+curl -N http://localhost:3000/v1/rooms/ABC123/events
+```
+
+Each SSE `data:` block contains a JSON event with:
+
+- `type`
+- `timestamp`
+- `roomCode`
+- `data`
+
+Current event types:
+
+- `connected`
+- `room.created`
+- `participant.joined`
+- `participant.updated`
+- `participant.left`
+- `participant.offline`
+- `llm.request`
+- `llm.error`
+
+Example event:
+
+```json
+{
+  "type": "participant.joined",
+  "timestamp": 1743884000000,
+  "roomCode": "ABC123",
+  "data": {
+    "id": "worker-1",
+    "nickname": "worker-1",
+    "model": "llama3"
+  }
+}
+```
+
+## Inference API
+
+The inference API remains OpenAI-compatible and is scoped to a room.
+
+Base URL:
+
+```text
+http://localhost:3000/rooms/ABC123/v1/
+```
+
+### Model routing
+
+The `model` field controls routing:
+
+| Value | Behavior |
+| --- | --- |
+| `*` or `any` | random online participant |
+| `model:<name>` | first online participant matching the model name |
+| `<participant-id>` | specific participant |
 
 ### GET /rooms/:code/v1/models
 
-List available models and participants in the room. Returns OpenAI-compatible format.
-
-**curl:**
+List available room models in an OpenAI-compatible format.
 
 ```bash
 curl http://localhost:3000/rooms/ABC123/v1/models
 ```
 
-**Response:**
+### POST /rooms/:code/v1/responses
 
-```json
-{
-  "object": "list",
-  "data": [
-    {
-      "id": "participant-id",
-      "object": "model",
-      "created": 1234567890,
-      "owned_by": "alice",
-      "gambi": {
-        "nickname": "alice",
-        "model": "llama3",
-        "endpoint": "http://192.168.1.10:11434",
-        "capabilities": {
-          "openResponses": "supported",
-          "chatCompletions": "supported"
-        }
-      }
-    }
-  ]
-}
-```
-
-## Room Management
-
-### POST /rooms
-
-Create a new room.
+Proxy the OpenAI Responses API.
 
 ```bash
-curl -X POST http://localhost:3000/rooms \
-  -H "Content-Type: application/json" \
-  -d '{"name": "My Room"}'
-```
-
-Optional: `"password": "secret"` for password-protected rooms.
-
-**Response:**
-
-```json
-{
-  "room": {
-    "id": "uuid",
-    "code": "ABC123",
-    "name": "My Room",
-    "hostId": "uuid",
-    "createdAt": 1234567890
-  },
-  "hostId": "uuid"
-}
-```
-
-### GET /rooms
-
-List all rooms.
-
-```bash
-curl http://localhost:3000/rooms
-```
-
-### POST /rooms/:code/join
-
-Register a participant in a room.
-
-```bash
-curl -X POST http://localhost:3000/rooms/ABC123/join \
+curl -X POST http://localhost:3000/rooms/ABC123/v1/responses \
   -H "Content-Type: application/json" \
   -d '{
-    "id": "my-unique-id",
-    "nickname": "alice",
-    "model": "llama3",
-    "endpoint": "https://openrouter.ai/api",
-    "authHeaders": {
-      "Authorization": "Bearer sk-..."
-    }
+    "model": "*",
+    "input": "Hello!",
+    "stream": false
   }'
 ```
 
-Optional fields: `"password"`, `"specs"`, `"config"`, `"capabilities"`, `"authHeaders"`.
+The hub prefers the Responses protocol first.
 
-`authHeaders` are kept only in hub memory and are never returned by participant listing endpoints.
+Additional lifecycle endpoints:
 
-### DELETE /rooms/:code/leave/:participantId
+- `GET /rooms/:code/v1/responses/:id`
+- `DELETE /rooms/:code/v1/responses/:id`
+- `POST /rooms/:code/v1/responses/:id/cancel`
+- `GET /rooms/:code/v1/responses/:id/input_items`
 
-Remove a participant from a room.
+### POST /rooms/:code/v1/chat/completions
 
-```bash
-curl -X DELETE http://localhost:3000/rooms/ABC123/leave/my-unique-id
-```
-
-### GET /rooms/:code/participants
-
-List all participants in a room with their status.
+Proxy OpenAI-compatible chat completions.
 
 ```bash
-curl http://localhost:3000/rooms/ABC123/participants
-```
-
-### POST /rooms/:code/health
-
-Send a health check heartbeat. Participants must send this every 10 seconds to stay online. After 30 seconds without a heartbeat, the participant is marked offline.
-
-```bash
-curl -X POST http://localhost:3000/rooms/ABC123/health \
+curl -X POST http://localhost:3000/rooms/ABC123/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"id": "my-participant-id"}'
+  -d '{
+    "model": "*",
+    "messages": [
+      { "role": "user", "content": "Hello!" }
+    ]
+  }'
 ```
 
-### GET /health
+## Runtime defaults
 
-Check if the hub is running.
+The hub merges runtime defaults in this order:
 
-```bash
-curl http://localhost:3000/health
-```
+1. room defaults
+2. participant defaults
+3. request-time overrides
 
-## SSE Events
-
-### GET /rooms/:code/events
-
-Server-Sent Events stream for real-time monitoring.
-
-```bash
-curl -N http://localhost:3000/rooms/ABC123/events
-```
-
-Events emitted:
-- `room:created` — new room created
-- `participant:joined` — participant joined the room
-- `participant:left` — participant left the room
-- `participant:offline` — participant stopped sending health checks
-- `llm:request` — request was routed to a participant
-- `llm:error` — request to a participant failed
-
-## Using with AI Tools
-
-Point any tool that accepts an OpenAI-compatible base URL to:
-
-```
-http://<hub>:<port>/rooms/<CODE>/v1
-```
-
-### Lovable / Cursor / any OpenAI-compatible client
-
-- **Base URL:** `http://192.168.1.100:3000/rooms/ABC123/v1`
-- **API Key:** any string (not validated)
-- **Model:** `*` (any available) or a specific model name
-
-### Python (openai library)
-
-```python
-from openai import OpenAI
-
-client = OpenAI(
-    base_url="http://192.168.1.100:3000/rooms/ABC123/v1",
-    api_key="not-needed"
-)
-
-response = client.chat.completions.create(
-    model="*",
-    messages=[{"role": "user", "content": "Hello!"}]
-)
-print(response.choices[0].message.content)
-```
-
-### JavaScript (fetch)
-
-```javascript
-const response = await fetch(
-  "http://localhost:3000/rooms/ABC123/v1/chat/completions",
-  {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: "*",
-      messages: [{ role: "user", content: "Hello!" }],
-    }),
-  }
-);
-const data = await response.json();
-console.log(data.choices[0].message.content);
-```
+Sensitive config is redacted from public management payloads.

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -1,15 +1,27 @@
 ---
 title: CLI Reference
-description: Complete reference for Gambi CLI commands.
+description: Reference for the Gambi operational CLI.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-The Gambi CLI provides commands for managing hubs, rooms, and participants.
+The Gambi CLI is the operational surface for hubs, rooms, participants, and room events.
 
-All commands support **interactive mode** — run without flags in a terminal and you'll be guided through each option step by step. Flags still work for scripting and automation.
+The CLI is resource-oriented:
 
-If you're coming from the old package and binary names, read [Migrate from Gambiarra](/guides/migrate-from-gambiarra/).
+```bash
+gambi hub serve
+gambi room create
+gambi room list
+gambi room get
+gambi participant join
+gambi participant leave
+gambi participant heartbeat
+gambi events watch
+gambi self update
+```
+
+`gambi-tui` remains the separate human-first monitoring interface.
 
 ## Installation
 
@@ -31,254 +43,420 @@ If you're coming from the old package and binary names, read [Migrate from Gambi
     bun add -g gambi
     ```
 
-    The published `gambi` package is a wrapper that installs only the matching platform binary for your machine.
+    The published `gambi` package is a wrapper that installs the matching platform binary for the current machine.
   </TabItem>
 </Tabs>
 
-### Uninstallation
+The recommended path is the standalone installer via `curl` or PowerShell. npm and bun remain supported.
 
-<Tabs>
-  <TabItem label="Linux / macOS" icon="linux">
-    ```bash
-    curl -fsSL https://raw.githubusercontent.com/arthurbm/gambi/main/scripts/uninstall.sh | bash
-    ```
-  </TabItem>
-  <TabItem label="Windows" icon="laptop">
-    ```powershell
-    irm https://raw.githubusercontent.com/arthurbm/gambi/main/scripts/uninstall.ps1 | iex
-    ```
-  </TabItem>
-  <TabItem label="npm / bun" icon="seti:npm">
-    ```bash
-    npm uninstall -g gambi
-    # or
-    bun remove -g gambi
-    ```
-  </TabItem>
-</Tabs>
+Verify:
 
-## Interactive Mode
-
-When you run any command without its required flags in a terminal (TTY), the CLI enters interactive mode and prompts you for each option:
-
+```bash
+gambi --version
 ```
-┌  gambi join
+
+## Global behavior
+
+### Output modes
+
+Every operational command supports:
+
+| Mode | Meaning | Typical use |
+| --- | --- | --- |
+| `text` | compact human-readable output | local terminal usage |
+| `json` | one structured JSON object | scripts and API-style automation |
+| `ndjson` | one JSON object per line | streaming agents, logs, pipelines |
+
+Defaults:
+
+| Context | Default |
+| --- | --- |
+| TTY + one-shot command | `text` |
+| piped stdout + one-shot command | `json` |
+| piped stdout + streaming command | `ndjson` |
+
+### Interactive control
+
+The CLI does not assume interactive usage by default for every command.
+
+Interactive mode is still available when it helps humans fill in missing values:
+
+```text
+┌  gambi participant join
 │
 ◇  Room code:
 │  ABC123
 │
-◆  LLM Provider:
-│  ● Ollama (localhost:11434)
-│  ○ LM Studio (localhost:1234)
-│  ○ vLLM (localhost:8000)
-│  ○ Custom URL
+◇  Participant ID:
+│  worker-1
 │
-◇  Select model:
-│  llama3.2
+◆  Model:
+│  ● llama3
+│  ○ qwen2.5
+│  ○ mistral
 │
-└  Joined room ABC123!
+◇  Nickname (optional):
+│  llama3@worker
+│
+└  Registered participant worker-1.
 ```
 
-Interactive mode is disabled when piping input (`echo "x" | gambi create`), so scripts work as before.
+| Control | Behavior |
+| --- | --- |
+| `--interactive` | allow prompts for missing required values |
+| `--no-interactive` | disable all prompts |
+| `GAMBI_NO_INTERACTIVE=1` | disable prompts through the environment |
 
-## Commands
+Commands that never auto-prompt:
 
-### `serve`
+| Command | Auto-prompts? |
+| --- | --- |
+| `gambi hub serve` | no |
+| `gambi room list` | no |
+| `gambi room get` | no |
+| `gambi participant heartbeat` | no |
+| `gambi events watch` | no |
 
-Start a hub server.
+### Named environments
 
-```bash
-# Interactive — prompts for port, host, mDNS:
-gambi serve
+The CLI reads XDG config from:
 
-# With flags:
-gambi serve [options]
+```text
+~/.config/gambi/config.json
 ```
 
-**Options:**
+Use `--env <name>` or `GAMBI_ENV` to select an environment profile.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--port`, `-p` | Port to listen on | `3000` |
-| `--host`, `-h` | Host to bind to | `0.0.0.0` |
-| `--mdns`, `-m` | Enable mDNS auto-discovery | `false` |
-| `--quiet`, `-q` | Suppress logo output | `false` |
+Example:
 
-**Example:**
-
-```bash
-gambi serve --port 3000 --mdns
+```json
+{
+  "defaultEnv": "local",
+  "envs": {
+    "local": {
+      "hubUrl": "http://localhost:3000",
+      "endpoint": "http://localhost:11434"
+    },
+    "staging": {
+      "hubUrl": "http://192.168.1.10:3000",
+      "networkEndpoint": "http://192.168.1.25:11434",
+      "serve": {
+        "host": "0.0.0.0",
+        "port": 3000,
+        "mdns": true
+      }
+    }
+  }
+}
 ```
 
-### `create`
+### Exit codes
 
-Create a new room on a hub.
+Operational commands use deterministic exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | success |
+| `1` | internal or unexpected failure |
+| `2` | invalid usage or validation error |
+| `3` | connectivity or dependency failure |
+| `4` | remote rejection or conflict |
+
+## Command reference
+
+## `gambi hub serve`
+
+Start the Gambi hub.
 
 ```bash
-# Interactive — prompts for name and password:
-gambi create
-
-# With flags:
-gambi create --name "Room Name" [options]
+gambi hub serve [options]
 ```
 
-**Options:**
+Options:
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--name`, `-n` | Room name | Required (prompted in interactive mode) |
-| `--password`, `-p` | Password to protect the room | None |
-| `--hub`, `-H` | Hub URL | `http://localhost:3000` |
+| Option | Description |
+| --- | --- |
+| `--host` | host to bind to |
+| `--port` | port to bind to |
+| `--mdns` | enable mDNS discovery |
+| `--dry-run` | print the resolved startup plan and exit |
+| global flags | includes `--format`, `--env`, `--quiet`, `--verbose` |
 
-**Examples:**
+Examples:
 
 ```bash
-# Create a room interactively
-gambi create
-
-# Create with flags
-gambi create --name "My Room"
-
-# Create on a custom hub
-gambi create --name "My Room" --hub http://192.168.1.10:3000
-
-# Create a password-protected room
-gambi create --name "My Room" --password secret123
+gambi hub serve
+gambi hub serve --mdns
+gambi hub serve --dry-run --format json
 ```
 
-### `join`
+Machine-readable NDJSON events:
 
-Join a room and expose your LLM endpoint.
+| Event | Meaning |
+| --- | --- |
+| `started` | hub startup completed |
+| `mdns_registered` | mDNS registration succeeded |
+| `signal_received` | a shutdown signal was received |
+| `stopped` | shutdown completed |
+
+## `gambi room create`
+
+Create a room through the management API.
 
 ```bash
-# Interactive — select provider, model, set nickname:
-gambi join
-
-# With flags:
-gambi join --code <room-code> --model <model> [options]
+gambi room create --name <name> [options]
 ```
 
-**Options:**
+Options:
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--code`, `-c` | Room code to join | Required (prompted in interactive mode) |
-| `--model`, `-m` | Model to expose | Required (prompted in interactive mode) |
-| `--endpoint`, `-e` | Local LLM endpoint URL used for probing and inference | `http://localhost:11434` |
-| `--network-endpoint` | Network-reachable URL to publish to the hub | Auto-detected when needed |
-| `--nickname`, `-n` | Display name | Auto-generated |
-| `--header` | Auth header in the format `Header=Value` | None |
-| `--header-env` | Auth header in the format `Header=ENV_VAR` | None |
-| `--password`, `-p` | Room password (if protected) | None |
-| `--hub`, `-H` | Hub URL | `http://localhost:3000` |
-| `--no-specs` | Don't share machine specs | `false` |
-| `--no-network-rewrite` | Disable automatic localhost-to-LAN rewrite for remote hubs | `false` |
+| Option | Description |
+| --- | --- |
+| `--name` | room name |
+| `--password` | optional room password |
+| `--config &lt;path|-&gt;` | runtime config JSON file or stdin |
+| `--hub` | hub URL |
+| `--dry-run` | validate and preview the request |
 
-The CLI automatically probes your local endpoint to detect available models and protocol capabilities (Responses API vs Chat Completions).
+Notes:
 
-When the hub is remote and your local endpoint is loopback-only (for example `http://localhost:11434`), Gambi tries to publish a LAN-reachable URL automatically. In interactive mode, the CLI explains the rewrite and lets you confirm or override it. Use `--network-endpoint` when you want to publish a specific URL yourself.
+- `--config -` reads runtime config JSON from stdin.
+- In interactive mode, the CLI can prompt for `--name` and `--password`.
 
-In interactive mode, you'll select your LLM provider from a list (Ollama, LM Studio, vLLM, or custom URL), optionally add auth headers, and then choose from the detected models.
-
-**Examples:**
+Examples:
 
 ```bash
-# Join interactively — guided through all options
-gambi join
+gambi room create --name Demo
+gambi room create --name Demo --config ./room-defaults.json
+cat defaults.json | gambi room create --name Demo --config -
+gambi room create --name Demo --dry-run --format json
+```
 
-# Join with Ollama
-gambi join --code ABC123 --model llama3
+## `gambi room list`
 
-# Join with LM Studio
-gambi join --code ABC123 \
-  --model mistral \
+List room summaries from the management API.
+
+```bash
+gambi room list [options]
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--hub` | hub URL |
+| `--sort participant-count|created-at|name` | sort strategy |
+| `--reverse` | reverse the chosen sort order |
+
+Examples:
+
+```bash
+gambi room list
+gambi room list --format json
+gambi room list --hub http://192.168.1.10:3000
+```
+
+Default sort:
+
+1. participant count descending
+2. created date descending
+
+## `gambi room get`
+
+Fetch one room summary by code.
+
+```bash
+gambi room get --code <room-code> [options]
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--code` | room code |
+| `--hub` | hub URL |
+
+Examples:
+
+```bash
+gambi room get --code ABC123
+gambi room get --code ABC123 --format json
+```
+
+## `gambi participant join`
+
+Register a participant and keep heartbeats alive.
+
+```bash
+gambi participant join --room <room> --participant-id <id> --model <model> [options]
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--room` | room code |
+| `--participant-id` | stable participant identifier |
+| `--nickname` | display name |
+| `--model` | model to expose |
+| `--endpoint` | local endpoint used for probing and inference |
+| `--network-endpoint` | explicit network-reachable URL to publish |
+| `--header` | auth header in `Header=Value` format |
+| `--header-env` | auth header in `Header=ENV_VAR` format |
+| `--password` | room password |
+| `--config &lt;path|-&gt;` | runtime config JSON file or stdin |
+| `--no-specs` | skip machine specs collection |
+| `--hub` | hub URL |
+| `--dry-run` | validate and preview the registration |
+
+Notes:
+
+- `--participant-id` is required for non-interactive retry-safe automation.
+- `--config -` reads participant runtime config JSON from stdin.
+- The CLI probes the endpoint before registration to validate the model and detect capabilities.
+- When the hub is remote and the endpoint is loopback-only, Gambi tries to publish a LAN-reachable URL automatically unless `--network-endpoint` is provided.
+
+Examples:
+
+```bash
+gambi participant join \
+  --room ABC123 \
+  --participant-id worker-1 \
+  --model llama3
+
+gambi participant join \
+  --room ABC123 \
+  --participant-id worker-1 \
+  --model llama3 \
   --endpoint http://localhost:1234
 
-# Join a remote hub and publish an explicit LAN URL
-gambi join --code ABC123 \
+gambi participant join \
+  --room ABC123 \
+  --participant-id worker-1 \
+  --model llama3 \
+  --dry-run \
+  --format json
+
+gambi participant join \
+  --room ABC123 \
+  --participant-id worker-1 \
+  --model llama3 \
   --hub http://192.168.1.10:3000 \
-  --model llama3 \
-  --endpoint http://localhost:11434 \
   --network-endpoint http://192.168.1.25:11434
-
-# Join with custom nickname
-gambi join --code ABC123 \
-  --model llama3 \
-  --nickname "alice-4090"
-
-# Join a remote provider securely
-export OPENROUTER_AUTH="Bearer sk-or-..."
-gambi join --code ABC123 \
-  --model meta-llama/llama-3.1-8b-instruct:free \
-  --endpoint https://openrouter.ai/api \
-  --header-env Authorization=OPENROUTER_AUTH
-
-# Join a password-protected room
-gambi join --code ABC123 \
-  --model llama3 \
-  --password secret123
 ```
 
-### `list`
+NDJSON lifecycle events:
 
-List available rooms on a hub.
+| Event | Meaning |
+| --- | --- |
+| `prepared` | endpoint probing and payload assembly completed |
+| `registered` | participant registration succeeded |
+| `heartbeat_ok` | heartbeat loop is healthy |
+| `heartbeat_failed` | one heartbeat attempt failed |
+| `leaving` | shutdown started |
+| `left` | participant removal completed |
+| `error` | an operational error occurred |
+
+## `gambi participant leave`
+
+Remove a participant from a room.
 
 ```bash
-# Interactive — prompts for hub URL and output format:
-gambi list
-
-# With flags:
-gambi list [options]
+gambi participant leave --room <room> --participant-id <id> [options]
 ```
 
-**Options:**
+Options:
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--hub`, `-H` | Hub URL | `http://localhost:3000` |
-| `--json`, `-j` | Output as JSON | `false` |
+| Option | Description |
+| --- | --- |
+| `--room` | room code |
+| `--participant-id` | participant identifier |
+| `--hub` | hub URL |
 
-**Example:**
+Example:
 
 ```bash
-gambi list
-# Output:
-# Available rooms:
-#   ABC123  My Room
-#     Participants: 3
-#   XYZ789  Test Room
-#     Participants: 1
-
-gambi list --json
+gambi participant leave --room ABC123 --participant-id worker-1
 ```
 
-### `monitor`
+## `gambi participant heartbeat`
 
-Open the TUI to monitor rooms in real-time.
+Send a single participant heartbeat.
 
 ```bash
-gambi monitor [options]
+gambi participant heartbeat --room <room> --participant-id <id> [options]
 ```
 
-**Options:**
+Options:
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--hub`, `-H` | Hub URL | `http://localhost:3000` |
+| Option | Description |
+| --- | --- |
+| `--room` | room code |
+| `--participant-id` | participant identifier |
+| `--hub` | hub URL |
 
-The monitor shows participants, their status (online/offline), and a live activity log of events (joins, requests, errors) via SSE.
+Example:
 
-**Tip:** The standalone CLI currently shows help when you run `gambi` without arguments. Use `gambi monitor` to open the TUI.
+```bash
+gambi participant heartbeat --room ABC123 --participant-id worker-1
+```
 
-## Supported Providers
+## `gambi events watch`
 
-Gambi works with any endpoint that exposes OpenResponses or OpenAI-compatible `chat/completions`:
+Stream typed room events from the management API.
 
-| Provider | Default Endpoint | Protocols |
-|----------|------------------|-----------|
-| Ollama | `http://localhost:11434` | Responses API, Chat Completions |
-| LM Studio | `http://localhost:1234` | Responses API, Chat Completions |
-| LocalAI | `http://localhost:8080` | Responses API, Chat Completions |
-| vLLM | `http://localhost:8000` | Responses API, Chat Completions |
+```bash
+gambi events watch --room <room> [options]
+```
 
-For cloud providers (OpenRouter, Together AI, Groq, etc.), see the [Remote Providers](/guides/remote-providers/) guide.
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--room` | room code |
+| `--hub` | hub URL |
+
+Examples:
+
+```bash
+gambi events watch --room ABC123
+gambi events watch --room ABC123 --format ndjson
+```
+
+In NDJSON mode, the CLI relays the room event objects directly.
+
+## `gambi self update`
+
+Update the installed CLI.
+
+```bash
+gambi self update [options]
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--manager` | preferred package manager, such as `bun` or `npm` |
+| `--yes` | skip confirmation |
+| `--dry-run` | print the resolved update plan and exit |
+
+Examples:
+
+```bash
+gambi self update --dry-run --format json
+gambi self update --yes
+```
+
+## Environment variables
+
+| Variable | Meaning |
+| --- | --- |
+| `NO_COLOR=1` | disable ANSI colors |
+| `GAMBI_FORMAT` | set default output format |
+| `GAMBI_ENV` | select the named environment |
+| `GAMBI_NO_INTERACTIVE=1` | disable interactive prompts |
+
+## See also
+
+- [API Reference](/reference/api/)
+- [SDK Reference](/reference/sdk/)

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -162,6 +162,8 @@ Operational commands use deterministic exit codes:
 | `3` | connectivity or dependency failure |
 | `4` | remote rejection or conflict |
 
+Streaming commands always emit NDJSON for machine-readable output. If you pass `--format json` to a streaming command, the CLI coerces it to `ndjson`.
+
 ## Command reference
 
 ## `gambi hub serve`
@@ -187,7 +189,7 @@ Examples:
 ```bash
 gambi hub serve
 gambi hub serve --mdns
-gambi hub serve --dry-run --format json
+gambi hub serve --dry-run --format ndjson
 ```
 
 Machine-readable NDJSON events:
@@ -334,7 +336,7 @@ gambi participant join \
   --participant-id worker-1 \
   --model llama3 \
   --dry-run \
-  --format json
+  --format ndjson
 
 gambi participant join \
   --room ABC123 \

--- a/apps/docs/src/content/docs/reference/sdk.md
+++ b/apps/docs/src/content/docs/reference/sdk.md
@@ -1,9 +1,12 @@
 ---
 title: SDK Reference
-description: Complete reference for the Gambi SDK.
+description: Reference for the Gambi SDK provider, management client, and discovery helpers.
 ---
 
-The Gambi SDK provides a [Vercel AI SDK](https://sdk.vercel.ai/) provider for using shared LLMs through a Gambi hub.
+The Gambi SDK exposes two distinct entry points:
+
+- `createGambi()` for inference through the room-scoped OpenAI-compatible endpoints
+- `createClient()` for management operations against the native `/v1` API
 
 ## Installation
 
@@ -13,18 +16,37 @@ npm install gambi-sdk
 bun add gambi-sdk
 ```
 
+## SDK surfaces
+
+| Surface | Primary use | Transport |
+| --- | --- | --- |
+| `createGambi()` | application inference | `/rooms/:code/v1/*` |
+| `createClient()` | operational control | `/v1/*` |
+| discovery helpers | local-network room and hub resolution | mDNS + management API |
+
+## When to use what
+
+| Use case | Recommended API |
+| --- | --- |
+| send prompts and receive model output | `createGambi()` |
+| create a room or inspect rooms | `createClient().rooms.*` |
+| register or remove participants | `createClient().participants.*` |
+| watch live room events | `createClient().events.watchRoom()` |
+| discover hubs and rooms on the local network | `discoverHubs()`, `discoverRooms()`, `resolveGambiTarget()` |
+
 ## Local Network Discovery
 
-For local Node.js or Bun applications, the SDK can discover hubs and rooms announced over mDNS/Bonjour.
+For local Node.js and Bun applications, the SDK can discover hubs and rooms announced over mDNS/Bonjour.
 
 These helpers are optional. `createGambi()` and `createClient()` stay explicit and keep working with `hubUrl` and `roomCode` directly.
 
-```typescript
+```ts
 import { createClient, createGambi, resolveGambiTarget } from "gambi-sdk";
-// or import only discovery: import { resolveGambiTarget } from "gambi-sdk/discovery";
+// or import only discovery helpers:
+// import { resolveGambiTarget } from "gambi-sdk/discovery";
 
 const target = await resolveGambiTarget({
-  roomCode: "ABC123", // optional if exactly one room is available
+  roomCode: "ABC123",
   timeoutMs: 1500,
 });
 
@@ -41,57 +63,75 @@ const client = createClient({ hubUrl: target.hubUrl });
 Discover reachable hubs from the configured `hubUrl` seed plus mDNS services on the local network.
 
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `hubUrl` | `string` | `http://localhost:3000` | Seed hub to probe before mDNS results |
-| `timeoutMs` | `number` | `1500` | How long to listen for mDNS announcements |
+| --- | --- | --- | --- |
+| `hubUrl` | `string` | `http://localhost:3000` | seed hub to probe before mDNS results |
+| `timeoutMs` | `number` | `1500` | how long to listen for mDNS announcements |
 
 Returns `Promise<DiscoveredHub[]>`.
 
+Each discovered hub includes:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | display name for the hub |
+| `hubUrl` | `string` | resolved base URL |
+| `source` | `"configured" \| "mdns"` | where the hub came from |
+| `host` | `string` | advertised host |
+| `port` | `number` | advertised port |
+| `addresses` | `string[]` | resolved addresses |
+| `txt` | `Record<string, string>` | mDNS TXT records |
+
 ### `discoverRooms(options?)`
 
-Discover rooms by listing `/rooms` on each reachable hub found by `discoverHubs()`.
+Discover rooms by listing `/v1/rooms` on each reachable hub found by `discoverHubs()`.
 
 The options are the same as `discoverHubs(options?)`.
 
 Returns `Promise<DiscoveredRoom[]>`.
+
+Each discovered room extends the room summary with:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `hubName` | `string` | human-readable hub name |
+| `hubSource` | `"configured" \| "mdns"` | discovery source |
+| `hubUrl` | `string` | hub base URL for the room |
 
 ### `resolveGambiTarget(options?)`
 
 Resolve one room to a concrete `{ hubUrl, roomCode }` target you can pass into `createGambi()` or `createClient()`.
 
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `roomCode` | `string` | — | Resolve a specific room code across discovered hubs |
-| `roomName` | `string` | — | Resolve a specific room name across discovered hubs |
-| `hubUrl` | `string` | `http://localhost:3000` | Seed hub to probe before mDNS results |
-| `timeoutMs` | `number` | `1500` | How long to listen for mDNS announcements |
+| --- | --- | --- | --- |
+| `roomCode` | `string` | — | resolve a specific room code across discovered hubs |
+| `roomName` | `string` | — | resolve a specific room name across discovered hubs |
+| `hubUrl` | `string` | `http://localhost:3000` | seed hub to probe before mDNS results |
+| `timeoutMs` | `number` | `1500` | how long to listen for mDNS announcements |
 
 Behavior:
 
 - if exactly one room matches, it returns a `ResolvedGambiTarget`
-- if no rooms are found, it throws `DiscoveryError`
+- if no hubs are found, it throws `DiscoveryError` with `code = "NO_HUBS_FOUND"`
+- if no rooms are found, it throws `DiscoveryError` with `code = "NO_ROOMS_FOUND"`
+- if no room matches the requested filters, it throws `DiscoveryError` with `code = "ROOM_NOT_FOUND"`
 - if multiple rooms match, it throws `DiscoveryError` with `code = "AMBIGUOUS_ROOM_MATCH"`
 
 ### `DiscoveryError`
 
-Typed error thrown by `resolveGambiTarget()`.
+Typed error thrown by discovery helpers such as `resolveGambiTarget()`.
 
 | Field | Type | Description |
-|-------|------|-------------|
-| `code` | `"NO_HUBS_FOUND" \| "NO_ROOMS_FOUND" \| "ROOM_NOT_FOUND" \| "AMBIGUOUS_ROOM_MATCH"` | Discovery failure category |
-| `matches` | `DiscoveredRoom[]` | Matching rooms when resolution is ambiguous |
+| --- | --- | --- |
+| `code` | `"NO_HUBS_FOUND" \| "NO_ROOMS_FOUND" \| "ROOM_NOT_FOUND" \| "AMBIGUOUS_ROOM_MATCH"` | discovery failure category |
+| `matches` | `DiscoveredRoom[]` | matching rooms when resolution is ambiguous |
+
+## Inference provider
 
 ## `createGambi(options)`
 
 Creates a Gambi provider instance.
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `roomCode` | `string` | — | Room code to connect to. Required. |
-| `hubUrl` | `string` | `http://localhost:3000` | Hub URL |
-| `defaultProtocol` | `"openResponses" \| "chatCompletions"` | `"openResponses"` | Protocol used by the top-level routing helpers |
-
-```typescript
+```ts
 import { createGambi } from "gambi-sdk";
 
 const gambi = createGambi({
@@ -100,18 +140,24 @@ const gambi = createGambi({
 });
 ```
 
-## Protocol Selection
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `roomCode` | `string` | — | room code to connect to. Required. |
+| `hubUrl` | `string` | `http://localhost:3000` | hub URL |
+| `defaultProtocol` | `"openResponses" \| "chatCompletions"` | `"openResponses"` | protocol used by the top-level routing helpers |
+
+## Protocol selection
 
 The SDK defaults to `openResponses`. Both protocols are first-class:
 
-```typescript
+```ts
 // Default: Responses API
 const gambi = createGambi({
   roomCode: "ABC123",
 });
 
 // Chat Completions
-const gambi = createGambi({
+const legacy = createGambi({
   roomCode: "ABC123",
   defaultProtocol: "chatCompletions",
 });
@@ -119,46 +165,27 @@ const gambi = createGambi({
 
 You can also select per-call via namespaces:
 
-```typescript
-gambi.openResponses.any();      // Responses API
-gambi.chatCompletions.any();    // Chat Completions
+```ts
+gambi.openResponses.any();   // Responses API
+gambi.chatCompletions.any(); // Chat Completions
 ```
 
-## Model Routing
+## Model routing
 
 Three routing methods are available. All return a Vercel AI SDK model instance.
 
-### `gambi.any()`
+| Method | Description |
+| --- | --- |
+| `gambi.any()` | routes to a random online participant |
+| `gambi.participant(id)` | routes to a specific participant by ID |
+| `gambi.model(name)` | routes to the first online participant with that model |
 
-Routes to a random online participant.
+Examples:
 
-```typescript
-const result = await generateText({
-  model: gambi.any(),
-  prompt: "Hello",
-});
-```
-
-### `gambi.participant(id)`
-
-Routes to a specific participant by nickname or ID.
-
-```typescript
-const result = await generateText({
-  model: gambi.participant("alice"),
-  prompt: "Hello",
-});
-```
-
-### `gambi.model(name)`
-
-Routes to the first online participant running the specified model.
-
-```typescript
-const result = await generateText({
-  model: gambi.model("llama3"),
-  prompt: "Hello",
-});
+```ts
+gambi.any();
+gambi.participant("worker-1");
+gambi.model("llama3");
 ```
 
 All routing methods are also available under `gambi.openResponses.*` and `gambi.chatCompletions.*`.
@@ -167,7 +194,7 @@ All routing methods are also available under `gambi.openResponses.*` and `gambi.
 
 Use `streamText` from the Vercel AI SDK:
 
-```typescript
+```ts
 import { streamText } from "ai";
 
 const stream = await streamText({
@@ -180,11 +207,11 @@ for await (const chunk of stream.textStream) {
 }
 ```
 
-## Generation Options
+## Generation options
 
 Standard Vercel AI SDK options are supported:
 
-```typescript
+```ts
 const result = await generateText({
   model: gambi.any(),
   prompt: "Explain recursion",
@@ -193,37 +220,36 @@ const result = await generateText({
 });
 ```
 
-See the [Vercel AI SDK docs](https://sdk.vercel.ai/docs) for all available options.
+See the [Vercel AI SDK docs](https://sdk.vercel.ai/docs) for the full generation surface.
 
-## Querying the Room
+## Querying the room
 
 ### `gambi.listModels()`
 
 Returns all models available in the room.
 
-```typescript
+```ts
 const models = await gambi.listModels();
-// [{ id, nickname, model, endpoint, capabilities }]
 ```
 
 Each entry is a `GambiModel`:
 
 | Field | Type | Description |
-|-------|------|-------------|
-| `id` | `string` | Participant ID |
-| `nickname` | `string` | Display name |
-| `model` | `string` | Model name (e.g. `"llama3"`) |
-| `endpoint` | `string` | Participant endpoint URL |
-| `capabilities` | `object` | `{ openResponses, chatCompletions }` — `"supported"`, `"not-supported"`, or `"unknown"` |
+| --- | --- | --- |
+| `id` | `string` | participant ID |
+| `nickname` | `string` | display name |
+| `model` | `string` | model name, such as `"llama3"` |
+| `endpoint` | `string` | participant endpoint URL |
+| `capabilities` | `object` | `{ openResponses, chatCompletions }` capability summary |
 
 ### `gambi.listParticipants()`
 
-Returns all participants in the room with their full info (status, specs, config).
+Returns all participants in the room using the management API.
 
-```typescript
+```ts
 const participants = await gambi.listParticipants();
-for (const p of participants) {
-  console.log(p.nickname, p.model, p.status);
+for (const participant of participants) {
+  console.log(participant.nickname, participant.model, participant.status);
 }
 ```
 
@@ -231,136 +257,210 @@ for (const p of participants) {
 
 The computed base URL for the room's OpenAI-compatible API. Useful when you need to pass the URL to another tool or library.
 
-```typescript
+```ts
 console.log(gambi.baseURL);
 // "http://localhost:3000/rooms/ABC123/v1"
 ```
 
-## HTTP Client — `createClient(options)`
+## Management client
 
-The SDK also exports an HTTP client for managing rooms and participants programmatically. This is separate from the AI SDK provider — use it when you need to create rooms, join participants, or manage lifecycle from code.
+## `createClient(options)`
 
-```typescript
+The SDK also exports an HTTP client for managing rooms and participants programmatically. This is separate from the AI SDK provider.
+
+```ts
 import { createClient } from "gambi-sdk";
 
 const client = createClient({
-  hubUrl: "http://localhost:3000", // default
+  hubUrl: "http://localhost:3000",
 });
 ```
 
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `hubUrl` | `string` | `http://localhost:3000` | Hub URL |
+| --- | --- | --- | --- |
+| `hubUrl` | `string` | `http://localhost:3000` | hub URL |
 
-### `client.create(name, passwordOrOptions?)`
+Management methods return enveloped results:
 
-Create a new room. Returns `{ room, hostId }`.
-
-```typescript
-const { room, hostId } = await client.create("My Room");
-console.log(room.code); // "ABC123"
-
-// With password
-const { room } = await client.create("Private Room", "secret123");
-
-// With password and runtime defaults
-const { room } = await client.create("Room", {
-  password: "secret",
-  defaults: { temperature: 0.7 },
-});
+```ts
+const result = await client.rooms.list();
+console.log(result.data);
+console.log(result.meta.requestId);
 ```
 
-### `client.list()`
+### Namespace overview
 
-List all rooms. Returns `RoomInfoPublic[]`.
+| Namespace | Methods |
+| --- | --- |
+| `client.rooms` | `create`, `get`, `list` |
+| `client.participants` | `upsert`, `list`, `remove`, `heartbeat` |
+| `client.events` | `watchRoom` |
 
-```typescript
-const rooms = await client.list();
-for (const room of rooms) {
+### `client.rooms.create(input)`
+
+Create a new room. Returns `{ data: { room, hostId }, meta }`.
+
+```ts
+const created = await client.rooms.create({
+  name: "Demo",
+  password: "secret",
+  defaults: { temperature: 0.4 },
+});
+
+console.log(created.data.room.code);
+```
+
+Input fields:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | yes | room name |
+| `password` | `string` | no | room password |
+| `defaults` | `RuntimeConfig` | no | room runtime defaults |
+
+### `client.rooms.get(roomCode)`
+
+Fetch one room summary.
+
+```ts
+const room = await client.rooms.get("ABC123");
+console.log(room.data.name);
+```
+
+### `client.rooms.list()`
+
+List all room summaries.
+
+```ts
+const rooms = await client.rooms.list();
+for (const room of rooms.data) {
   console.log(room.code, room.name);
 }
 ```
 
-### `client.join(code, participant)`
+### `client.participants.upsert(roomCode, participantId, input)`
 
-Join a room as a participant.
+Create or update a participant registration. This maps to the idempotent management route.
 
-```typescript
-const { participant, roomId } = await client.join("ABC123", {
-  id: "my-bot",
-  nickname: "Bot",
+```ts
+const registered = await client.participants.upsert("ABC123", "worker-1", {
+  nickname: "worker-1",
   model: "llama3",
-  endpoint: "http://localhost:11434",
-  password: "secret123", // if room is protected
+  endpoint: "http://192.168.1.25:11434",
+  capabilities: {
+    openResponses: "supported",
+    chatCompletions: "supported",
+  },
 });
 ```
 
-Full participant options:
+Input fields:
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | `string` | yes | Unique participant ID |
-| `nickname` | `string` | yes | Display name |
-| `model` | `string` | yes | Model name |
-| `endpoint` | `string` | yes | LLM endpoint URL |
-| `password` | `string` | no | Room password |
-| `specs` | `object` | no | Machine specs (CPU, RAM, GPU) |
-| `config` | `RuntimeConfig` | no | Runtime config overrides |
-| `capabilities` | `object` | no | Protocol capabilities |
-| `authHeaders` | `object` | no | Auth headers for the endpoint (kept in memory only) |
+| --- | --- | --- | --- |
+| `nickname` | `string` | yes | display name |
+| `model` | `string` | yes | model name |
+| `endpoint` | `string` | yes | participant endpoint URL |
+| `password` | `string` | no | room password |
+| `specs` | `object` | no | machine specs |
+| `config` | `RuntimeConfig` | no | participant runtime defaults |
+| `capabilities` | `object` | no | protocol capability summary |
+| `authHeaders` | `object` | no | endpoint auth headers, kept only in hub memory |
 
-### `client.leave(code, participantId)`
+This method is retry-safe because the underlying management route is idempotent.
+
+### `client.participants.list(roomCode)`
+
+List all participants in a room.
+
+```ts
+const participants = await client.participants.list("ABC123");
+```
+
+### `client.participants.remove(roomCode, participantId)`
 
 Remove a participant from a room.
 
-```typescript
-await client.leave("ABC123", "my-bot");
+```ts
+await client.participants.remove("ABC123", "worker-1");
 ```
 
-### `client.getParticipants(code)`
+### `client.participants.heartbeat(roomCode, participantId)`
 
-List all participants in a room. Returns `ParticipantInfo[]`.
+Send one health check heartbeat.
 
-```typescript
-const participants = await client.getParticipants("ABC123");
+```ts
+await client.participants.heartbeat("ABC123", "worker-1");
 ```
 
-### `client.healthCheck(code, participantId)`
+Participants must keep sending heartbeats to stay online. The hub currently uses:
 
-Send a health check heartbeat. Participants must send this every 10 seconds to stay online (30 seconds timeout = offline).
+| Constant | Value |
+| --- | --- |
+| heartbeat interval | `10_000 ms` |
+| offline timeout | `30_000 ms` |
 
-```typescript
-// Keep alive loop
-setInterval(() => {
-  client.healthCheck("ABC123", "my-bot");
-}, 10_000);
+### `client.events.watchRoom({ roomCode, signal? })`
+
+Watch room events as an async iterable.
+
+```ts
+for await (const event of client.events.watchRoom({ roomCode: "ABC123" })) {
+  console.log(event.type, event.data);
+}
 ```
 
-### `ClientError`
+The yielded event shape mirrors the management SSE contract:
 
-All client methods throw `ClientError` on failure. It includes the HTTP status and response body.
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `string` | event name |
+| `timestamp` | `number` | event timestamp in milliseconds |
+| `roomCode` | `string` | room identifier |
+| `data` | `unknown` | event payload |
 
-```typescript
+## Errors
+
+## `ClientError`
+
+Management operations throw `ClientError` on failure.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status` | `number` | HTTP status |
+| `code` | `string \| undefined` | typed management error code |
+| `hint` | `string \| undefined` | human-readable remediation hint |
+| `details` | `unknown` | optional structured details |
+| `requestId` | `string \| undefined` | management request identifier |
+
+Example:
+
+```ts
 import { ClientError } from "gambi-sdk";
 
 try {
-  await client.join("INVALID", { /* ... */ });
-} catch (err) {
-  if (err instanceof ClientError) {
-    console.error(err.status);   // 404
-    console.error(err.response); // { error: "Room not found" }
+  await client.rooms.get("INVALID");
+} catch (error) {
+  if (error instanceof ClientError) {
+    console.error(error.status);
+    console.error(error.code);
+    console.error(error.hint);
+    console.error(error.requestId);
   }
 }
 ```
 
-## Key Types
+## Key types
 
-| Type | Import | Description |
-|------|--------|-------------|
-| `GambiProvider` | `gambi-sdk` | Return type of `createGambi()` |
-| `GambiClient` | `gambi-sdk` | Return type of `createClient()` |
-| `GambiModel` | `gambi-sdk` | Model info from `listModels()` |
-| `ParticipantInfo` | `gambi-sdk` | Full participant info |
-| `RoomInfoPublic` | `gambi-sdk` | Room info from `client.list()` |
-| `RuntimeConfig` | `gambi-sdk` | Generation config (temperature, maxTokens, etc.) |
-| `ClientError` | `gambi-sdk` | Error class for client failures |
+| Type | Description |
+| --- | --- |
+| `GambiProvider` | return type of `createGambi()` |
+| `GambiClient` | return type of `createClient()` |
+| `GambiModel` | model info from `gambi.listModels()` |
+| `DiscoveredHub` | hub discovered through configured seed or mDNS |
+| `DiscoveredRoom` | discovered room with hub metadata |
+| `ResolvedGambiTarget` | resolved `{ hub, room }` target |
+| `RoomSummary` | room summary transport type |
+| `ParticipantSummary` | participant summary transport type |
+| `RoomEvent` | typed room event payload |
+| `ClientError` | management client error type |

--- a/apps/tui/src/__tests__/factories.ts
+++ b/apps/tui/src/__tests__/factories.ts
@@ -32,6 +32,7 @@ export function createParticipant(
     endpoint: "http://localhost:11434",
     status: "online",
     joinedAt: now,
+    updatedAt: now,
     lastSeen: now,
     specs: {},
     config: { hasInstructions: false },

--- a/apps/tui/src/components/add-room-modal.tsx
+++ b/apps/tui/src/components/add-room-modal.tsx
@@ -26,7 +26,7 @@ export function AddRoomModal({ onAdd, onCancel }: AddRoomModalProps) {
 
     try {
       // Verify room exists
-      const response = await fetch(`${hubUrl}/rooms/${code}/participants`);
+      const response = await fetch(`${hubUrl}/v1/rooms/${code}`);
       if (!response.ok) {
         throw new Error("Room not found");
       }

--- a/apps/tui/src/components/room-selector.tsx
+++ b/apps/tui/src/components/room-selector.tsx
@@ -1,4 +1,4 @@
-import { RoomInfoPublic as RoomInfoSchema } from "@gambi/core/types";
+import { RoomSummary as RoomInfoSchema } from "@gambi/core/types";
 import { useKeyboard } from "@opentui/react";
 import { useCallback, useEffect, useState } from "react";
 import { z } from "zod";
@@ -33,17 +33,13 @@ export function RoomSelector({
         setLoading(true);
         setError(null);
 
-        const response = await fetch(`${hubUrl}/rooms`);
+        const response = await fetch(`${hubUrl}/v1/rooms`);
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
 
-        const data: unknown = await response.json();
-        const roomsArray =
-          data && typeof data === "object" && "rooms" in data
-            ? (data as { rooms: unknown }).rooms
-            : data;
-        const parsed = z.array(RoomInfoSchema).safeParse(roomsArray);
+        const envelope = (await response.json()) as { data?: unknown };
+        const parsed = z.array(RoomInfoSchema).safeParse(envelope.data ?? envelope);
         if (!parsed.success) {
           throw new Error("Invalid room data");
         }
@@ -53,11 +49,12 @@ export function RoomSelector({
           parsed.data.map(async (room) => {
             try {
               const participantsRes = await fetch(
-                `${hubUrl}/rooms/${room.code}/participants`
+                `${hubUrl}/v1/rooms/${room.code}/participants`
               );
-              const participants = participantsRes.ok
-                ? await participantsRes.json()
-                : [];
+              const participantsEnvelope = participantsRes.ok
+                ? ((await participantsRes.json()) as { data?: unknown })
+                : undefined;
+              const participants = participantsEnvelope?.data ?? [];
               return {
                 ...room,
                 selected: false,

--- a/apps/tui/src/hooks/queries/use-hub-health-query.ts
+++ b/apps/tui/src/hooks/queries/use-hub-health-query.ts
@@ -9,7 +9,7 @@ interface HubHealthResult {
 }
 
 async function checkHubHealth(url: string): Promise<HubHealthResult> {
-  const response = await fetch(`${url}/health`, {
+  const response = await fetch(`${url}/v1/health`, {
     method: "GET",
     signal: AbortSignal.timeout(5000),
   });

--- a/apps/tui/src/hooks/queries/use-rooms-query.ts
+++ b/apps/tui/src/hooks/queries/use-rooms-query.ts
@@ -3,7 +3,7 @@ import {
   type ParticipantAuthHeaders,
   type ParticipantCapabilities,
   ParticipantInfo,
-  RoomInfoPublic,
+  RoomSummary,
   type RuntimeConfig,
 } from "@gambi/core/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -14,16 +14,10 @@ import { useAppStore } from "../../store/app-store";
 // Schemas
 // ============================================================================
 
-const ListRoomsResponse = z.object({
-  rooms: z.array(
-    RoomInfoPublic.extend({
-      participantCount: z.number().optional(),
-    })
-  ),
-});
+const ListRoomsResponse = z.array(RoomSummary);
 
 const CreateRoomResponse = z.object({
-  room: RoomInfoPublic,
+  room: RoomSummary,
   hostId: z.string(),
 });
 
@@ -36,9 +30,7 @@ const SuccessResponse = z.object({
   success: z.literal(true),
 });
 
-const ParticipantsResponse = z.object({
-  participants: z.array(ParticipantInfo),
-});
+const ParticipantsResponse = z.array(ParticipantInfo);
 
 // ============================================================================
 // Types
@@ -98,13 +90,17 @@ async function fetchAndParse<T>(
   if (!response.ok) {
     const errorBody = await response.json().catch(() => ({}));
     const errorMessage =
-      (errorBody as { error?: string }).error ||
+      (errorBody as { error?: { message?: string } }).error?.message ||
       `HTTP ${response.status}: ${response.statusText}`;
     throw new Error(errorMessage);
   }
 
-  const data: unknown = await response.json();
-  return schema.parse(data);
+  const envelope: unknown = await response.json();
+  const rawData =
+    envelope && typeof envelope === "object" && "data" in envelope
+      ? (envelope as { data: unknown }).data
+      : envelope;
+  return schema.parse(rawData);
 }
 
 // ============================================================================
@@ -116,7 +112,7 @@ export function useRoomsList() {
 
   return useQuery({
     queryKey: roomKeys.list(),
-    queryFn: () => fetchAndParse(`${hubUrl}/rooms`, ListRoomsResponse),
+    queryFn: () => fetchAndParse(`${hubUrl}/v1/rooms`, ListRoomsResponse),
   });
 }
 
@@ -127,7 +123,7 @@ export function useParticipants(roomCode: string) {
     queryKey: roomKeys.participants(roomCode),
     queryFn: () =>
       fetchAndParse(
-        `${hubUrl}/rooms/${roomCode}/participants`,
+        `${hubUrl}/v1/rooms/${roomCode}/participants`,
         ParticipantsResponse
       ),
     enabled: Boolean(roomCode),
@@ -144,7 +140,7 @@ export function useCreateRoom() {
 
   return useMutation({
     mutationFn: (data: CreateRoomData) =>
-      fetchAndParse(`${hubUrl}/rooms`, CreateRoomResponse, {
+      fetchAndParse(`${hubUrl}/v1/rooms`, CreateRoomResponse, {
         method: "POST",
         body: JSON.stringify(data),
       }),
@@ -159,10 +155,14 @@ export function useJoinRoom() {
 
   return useMutation({
     mutationFn: ({ code, data }: { code: string; data: JoinParticipantData }) =>
-      fetchAndParse(`${hubUrl}/rooms/${code}/join`, JoinRoomResponse, {
-        method: "POST",
-        body: JSON.stringify(data),
-      }),
+      fetchAndParse(
+        `${hubUrl}/v1/rooms/${code}/participants/${data.id}`,
+        JoinRoomResponse,
+        {
+          method: "PUT",
+          body: JSON.stringify(data),
+        }
+      ),
   });
 }
 
@@ -179,7 +179,7 @@ export function useLeaveRoom() {
       participantId: string;
     }) =>
       fetchAndParse(
-        `${hubUrl}/rooms/${code}/leave/${participantId}`,
+        `${hubUrl}/v1/rooms/${code}/participants/${participantId}`,
         SuccessResponse,
         { method: "DELETE" }
       ),
@@ -200,9 +200,12 @@ export function useHealthCheck() {
       code: string;
       participantId: string;
     }) =>
-      fetchAndParse(`${hubUrl}/rooms/${code}/health`, SuccessResponse, {
-        method: "POST",
-        body: JSON.stringify({ id: participantId }),
-      }),
+      fetchAndParse(
+        `${hubUrl}/v1/rooms/${code}/participants/${participantId}/heartbeat`,
+        SuccessResponse,
+        {
+          method: "POST",
+        }
+      ),
   });
 }

--- a/apps/tui/src/hooks/use-hub-api.test.ts
+++ b/apps/tui/src/hooks/use-hub-api.test.ts
@@ -88,10 +88,15 @@ describe("fetchJson", () => {
   test("extracts error message from response body", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
-        new Response(JSON.stringify({ error: "Room not found" }), {
+        new Response(
+          JSON.stringify({
+            error: { message: "Room not found" },
+          }),
+          {
           status: 404,
           statusText: "Not Found",
-        })
+          }
+        )
       )
     ) as unknown as typeof fetch;
 

--- a/apps/tui/src/hooks/use-hub-api.ts
+++ b/apps/tui/src/hooks/use-hub-api.ts
@@ -3,7 +3,7 @@ import {
   type ParticipantAuthHeaders,
   type ParticipantCapabilities,
   ParticipantInfo,
-  RoomInfoPublic,
+  RoomSummary,
   type RuntimeConfig,
 } from "@gambi/core/types";
 import { useCallback } from "react";
@@ -22,17 +22,11 @@ const HealthResponse = z.object({
 });
 
 const CreateRoomResponse = z.object({
-  room: RoomInfoPublic,
+  room: RoomSummary,
   hostId: z.string(),
 });
 
-const ListRoomsResponse = z.object({
-  rooms: z.array(
-    RoomInfoPublic.extend({
-      participantCount: z.number().optional(),
-    })
-  ),
-});
+const ListRoomsResponse = z.array(RoomSummary);
 
 const JoinRoomResponse = z.object({
   participant: ParticipantInfo,
@@ -43,9 +37,7 @@ const SuccessResponse = z.object({
   success: z.literal(true),
 });
 
-const ParticipantsResponse = z.object({
-  participants: z.array(ParticipantInfo),
-});
+const ParticipantsResponse = z.array(ParticipantInfo);
 
 // Inferred types
 type HealthResponse = z.infer<typeof HealthResponse>;
@@ -122,13 +114,17 @@ export async function fetchJson<T>(
     if (!response.ok) {
       const errorBody = await response.json().catch(() => ({}));
       const errorMessage =
-        (errorBody as { error?: string }).error ||
+        (errorBody as { error?: { message?: string } }).error?.message ||
         `HTTP ${response.status}: ${response.statusText}`;
       return createErrorResult(errorMessage);
     }
 
-    const data: unknown = await response.json();
-    const parsed = schema.safeParse(data);
+    const envelope: unknown = await response.json();
+    const rawData =
+      envelope && typeof envelope === "object" && "data" in envelope
+        ? (envelope as { data: unknown }).data
+        : envelope;
+    const parsed = schema.safeParse(rawData);
 
     if (!parsed.success) {
       return createErrorResult(`Invalid response: ${parsed.error.message}`);
@@ -150,19 +146,19 @@ export function useHubApi(): UseHubApiReturn {
 
   const checkHub = useCallback(
     (): Promise<ApiResult<HealthResponse>> =>
-      fetchJson(`${hubUrl}/health`, HealthResponse),
+      fetchJson(`${hubUrl}/v1/health`, HealthResponse),
     [hubUrl]
   );
 
   const listRooms = useCallback(
     (): Promise<ApiResult<ListRoomsResponse>> =>
-      fetchJson(`${hubUrl}/rooms`, ListRoomsResponse),
+      fetchJson(`${hubUrl}/v1/rooms`, ListRoomsResponse),
     [hubUrl]
   );
 
   const createRoom = useCallback(
     (data: CreateRoomData): Promise<ApiResult<CreateRoomResponse>> =>
-      fetchJson(`${hubUrl}/rooms`, CreateRoomResponse, {
+      fetchJson(`${hubUrl}/v1/rooms`, CreateRoomResponse, {
         method: "POST",
         body: JSON.stringify(data),
       }),
@@ -174,10 +170,14 @@ export function useHubApi(): UseHubApiReturn {
       code: string,
       participantData: JoinParticipantData
     ): Promise<ApiResult<JoinRoomResponse>> =>
-      fetchJson(`${hubUrl}/rooms/${code}/join`, JoinRoomResponse, {
-        method: "POST",
-        body: JSON.stringify(participantData),
-      }),
+      fetchJson(
+        `${hubUrl}/v1/rooms/${code}/participants/${participantData.id}`,
+        JoinRoomResponse,
+        {
+          method: "PUT",
+          body: JSON.stringify(participantData),
+        }
+      ),
     [hubUrl]
   );
 
@@ -187,7 +187,7 @@ export function useHubApi(): UseHubApiReturn {
       participantId: string
     ): Promise<ApiResult<SuccessResponse>> =>
       fetchJson(
-        `${hubUrl}/rooms/${code}/leave/${participantId}`,
+        `${hubUrl}/v1/rooms/${code}/participants/${participantId}`,
         SuccessResponse,
         {
           method: "DELETE",
@@ -201,16 +201,19 @@ export function useHubApi(): UseHubApiReturn {
       code: string,
       participantId: string
     ): Promise<ApiResult<SuccessResponse>> =>
-      fetchJson(`${hubUrl}/rooms/${code}/health`, SuccessResponse, {
-        method: "POST",
-        body: JSON.stringify({ id: participantId }),
-      }),
+      fetchJson(
+        `${hubUrl}/v1/rooms/${code}/participants/${participantId}/heartbeat`,
+        SuccessResponse,
+        {
+          method: "POST",
+        }
+      ),
     [hubUrl]
   );
 
   const getParticipants = useCallback(
     (code: string): Promise<ApiResult<ParticipantsResponse>> =>
-      fetchJson(`${hubUrl}/rooms/${code}/participants`, ParticipantsResponse),
+      fetchJson(`${hubUrl}/v1/rooms/${code}/participants`, ParticipantsResponse),
     [hubUrl]
   );
 

--- a/apps/tui/src/hooks/use-room.ts
+++ b/apps/tui/src/hooks/use-room.ts
@@ -44,12 +44,16 @@ export function useRoom(options: UseRoomOptions): UseRoomReturn {
   // Fetch initial participants
   const fetchParticipants = useCallback(async () => {
     try {
-      const response = await fetch(`${hubUrl}/rooms/${roomCode}/participants`);
+      const response = await fetch(
+        `${hubUrl}/v1/rooms/${roomCode}/participants`
+      );
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
-      const data = await response.json();
-      const parsed = z.array(ParticipantInfoSchema).safeParse(data);
+      const envelope = (await response.json()) as { data?: unknown };
+      const parsed = z
+        .array(ParticipantInfoSchema)
+        .safeParse(envelope.data ?? envelope);
       if (!parsed.success) {
         console.error("Invalid participants data:", parsed.error);
         return;
@@ -254,13 +258,13 @@ export function useRoom(options: UseRoomOptions): UseRoomReturn {
     (event: string, data: unknown) => {
       const handlers: Record<string, (d: unknown) => void> = {
         connected: handleConnected,
-        "room:created": handleRoomCreated,
-        "participant:joined": handleParticipantJoined,
-        "participant:left": handleParticipantLeft,
-        "participant:offline": handleParticipantOffline,
-        "llm:request": handleLlmRequest,
-        "llm:complete": handleLlmComplete,
-        "llm:error": handleLlmError,
+      "room.created": handleRoomCreated,
+      "participant.joined": handleParticipantJoined,
+      "participant.left": handleParticipantLeft,
+      "participant.offline": handleParticipantOffline,
+      "llm.request": handleLlmRequest,
+      "llm.complete": handleLlmComplete,
+      "llm.error": handleLlmError,
       };
       handlers[event]?.(data);
     },

--- a/apps/tui/src/hooks/use-rooms.test.ts
+++ b/apps/tui/src/hooks/use-rooms.test.ts
@@ -13,6 +13,7 @@ import {
   handleParticipantLeftEvent,
   handleParticipantOfflineEvent,
   handleRoomCreatedEvent,
+  unwrapSSEEventPayload,
 } from "./use-rooms";
 
 describe("handleConnectedEvent", () => {
@@ -28,6 +29,32 @@ describe("handleConnectedEvent", () => {
     const result = handleConnectedEvent(room);
 
     expect(result.log).toBeUndefined();
+  });
+});
+
+describe("unwrapSSEEventPayload", () => {
+  test("unwraps room event envelopes and prefers payload.type", () => {
+    const result = unwrapSSEEventPayload("participant.joined", {
+      type: "llm.complete",
+      timestamp: Date.now(),
+      roomCode: "ABC123",
+      data: { participantId: "p1", metrics: { latencyMs: 12 } },
+    });
+
+    expect(result).toEqual({
+      event: "llm.complete",
+      data: { participantId: "p1", metrics: { latencyMs: 12 } },
+    });
+  });
+
+  test("passes through legacy payloads unchanged", () => {
+    const payload = { participantId: "p1" };
+    const result = unwrapSSEEventPayload("participant.left", payload);
+
+    expect(result).toEqual({
+      event: "participant.left",
+      data: payload,
+    });
   });
 });
 

--- a/apps/tui/src/hooks/use-rooms.test.ts
+++ b/apps/tui/src/hooks/use-rooms.test.ts
@@ -75,6 +75,7 @@ describe("handleParticipantJoinedEvent", () => {
       status: "online",
       joinedAt: Date.now(),
       lastSeen: Date.now(),
+      updatedAt: Date.now(),
       specs: {},
       config: {},
     };
@@ -94,6 +95,7 @@ describe("handleParticipantJoinedEvent", () => {
       status: "online",
       joinedAt: Date.now(),
       lastSeen: Date.now(),
+      updatedAt: Date.now(),
       specs: {},
       config: {},
     };

--- a/apps/tui/src/hooks/use-rooms.ts
+++ b/apps/tui/src/hooks/use-rooms.ts
@@ -25,6 +25,13 @@ interface RoomConnection {
   connected: boolean;
 }
 
+interface RoomEventEnvelope {
+  type: string;
+  timestamp: number;
+  roomCode: string;
+  data: unknown;
+}
+
 interface UseRoomsReturn {
   rooms: Map<string, RoomState>;
   activeRoom: string | null;
@@ -36,6 +43,37 @@ interface UseRoomsReturn {
 }
 
 const RECONNECT_DELAY = 3000;
+
+function isRoomEventEnvelope(value: unknown): value is RoomEventEnvelope {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof value.type === "string" &&
+    "timestamp" in value &&
+    typeof value.timestamp === "number" &&
+    "roomCode" in value &&
+    typeof value.roomCode === "string" &&
+    "data" in value
+  );
+}
+
+export function unwrapSSEEventPayload(
+  fallbackEvent: string,
+  payload: unknown
+): { event: string; data: unknown } {
+  if (isRoomEventEnvelope(payload)) {
+    return {
+      event: payload.type,
+      data: payload.data,
+    };
+  }
+
+  return {
+    event: fallbackEvent,
+    data: payload,
+  };
+}
 
 // Types for event handler results - exported for testing
 export interface LogAction {
@@ -428,7 +466,11 @@ export function useRooms(): UseRoomsReturn {
         buffer = remaining;
 
         for (const sseEvent of events) {
-          handleSSEEvent(code, sseEvent.event, sseEvent.data);
+          const unwrapped = unwrapSSEEventPayload(
+            sseEvent.event,
+            sseEvent.data
+          );
+          handleSSEEvent(code, unwrapped.event, unwrapped.data);
         }
       }
     },

--- a/apps/tui/src/hooks/use-rooms.ts
+++ b/apps/tui/src/hooks/use-rooms.ts
@@ -326,13 +326,13 @@ export function useRooms(): UseRoomsReturn {
           (r: RoomState, d: unknown) => EventResult
         > = {
           connected: (r) => handleConnectedEvent(r),
-          "room:created": (r, d) => handleRoomCreatedEvent(r, code, d),
-          "participant:joined": handleParticipantJoinedEvent,
-          "participant:left": handleParticipantLeftEvent,
-          "participant:offline": handleParticipantOfflineEvent,
-          "llm:request": handleLlmRequestEvent,
-          "llm:complete": handleLlmCompleteEvent,
-          "llm:error": handleLlmErrorEvent,
+          "room.created": (r, d) => handleRoomCreatedEvent(r, code, d),
+          "participant.joined": handleParticipantJoinedEvent,
+          "participant.left": handleParticipantLeftEvent,
+          "participant.offline": handleParticipantOfflineEvent,
+          "llm.request": handleLlmRequestEvent,
+          "llm.complete": handleLlmCompleteEvent,
+          "llm.error": handleLlmErrorEvent,
         };
 
         const handler = handlers[event];
@@ -354,9 +354,9 @@ export function useRooms(): UseRoomsReturn {
 
       // Invalidate participant queries when relevant events occur
       if (
-        event === "participant:joined" ||
-        event === "participant:left" ||
-        event === "participant:offline"
+        event === "participant.joined" ||
+        event === "participant.left" ||
+        event === "participant.offline"
       ) {
         queryClient.invalidateQueries({
           queryKey: roomKeys.participants(code),
@@ -364,7 +364,7 @@ export function useRooms(): UseRoomsReturn {
       }
 
       // Invalidate room list when room is created
-      if (event === "room:created") {
+      if (event === "room.created") {
         queryClient.invalidateQueries({ queryKey: roomKeys.list() });
       }
     },
@@ -374,17 +374,13 @@ export function useRooms(): UseRoomsReturn {
   const fetchParticipants = useCallback(
     async (code: string) => {
       try {
-        const response = await fetch(`${hubUrl}/rooms/${code}/participants`);
+        const response = await fetch(`${hubUrl}/v1/rooms/${code}/participants`);
         if (!response.ok) {
           return;
         }
 
-        const data: unknown = await response.json();
-        // API returns { participants: [...] }
-        const participantsArray =
-          data && typeof data === "object" && "participants" in data
-            ? (data as { participants: unknown }).participants
-            : data;
+        const envelope = (await response.json()) as { data?: unknown };
+        const participantsArray = envelope.data ?? envelope;
         const parsed = z
           .array(ParticipantInfoSchema)
           .safeParse(participantsArray);
@@ -477,7 +473,7 @@ export function useRooms(): UseRoomsReturn {
       });
 
       try {
-        const response = await fetch(`${hubUrl}/rooms/${code}/events`, {
+        const response = await fetch(`${hubUrl}/v1/rooms/${code}/events`, {
           signal: abortController.signal,
           headers: { Accept: "text/event-stream" },
         });

--- a/apps/tui/src/hooks/use-sse.ts
+++ b/apps/tui/src/hooks/use-sse.ts
@@ -100,7 +100,7 @@ export function useSSE(options: UseSSEOptions): UseSSEReturn {
     abortControllerRef.current = controller;
 
     try {
-      const url = `${hubUrl}/rooms/${roomCode}/events`;
+      const url = `${hubUrl}/v1/rooms/${roomCode}/events`;
       const response = await fetchSSEResponse(url, controller.signal);
 
       setConnected(true);
@@ -164,7 +164,14 @@ export function tryParseEvent(
     return undefined;
   }
   try {
-    return { event: eventType, data: JSON.parse(eventData) };
+    const parsed = JSON.parse(eventData) as {
+      type?: string;
+      data?: unknown;
+    };
+    return {
+      event: parsed.type ?? eventType,
+      data: parsed.data ?? parsed,
+    };
   } catch {
     return undefined;
   }

--- a/apps/tui/src/screens/list-rooms.tsx
+++ b/apps/tui/src/screens/list-rooms.tsx
@@ -1,3 +1,4 @@
+import type { RoomSummary } from "@gambi/core/types";
 import { useKeyboard } from "@opentui/react";
 import { useCallback, useState } from "react";
 import { Footer } from "../components/footer";
@@ -34,10 +35,10 @@ export function ListRooms({ onNavigate, onBack, canGoBack }: ListRoomsProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const rooms: RoomData[] =
-    data?.rooms.map((room) => ({
+    data?.map((room: RoomSummary) => ({
       code: room.code,
       name: room.name,
-      participantCount: room.participantCount ?? 0,
+      participantCount: room.participantCount,
       createdAt: new Date(room.createdAt).toLocaleString(),
     })) ?? [];
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,338 +1,294 @@
-# Gambi - Architecture
+# Gambi Architecture
 
-This document describes the current architecture of Gambi, a system for sharing local LLMs across a network.
-
-`Gambi` is the official short form of **gambiarra**. The shorter name works better in English for CLI/package ergonomics, while preserving the PT-BR meaning of creative, resourceful improvisation under constraints.
+This document explains the current architecture of Gambi after the agent-first redesign of the operational surface.
 
 ## Overview
 
-Gambi enables multiple users on a local network to share their LLM endpoints (Ollama, LM Studio, LocalAI, vLLM, or any endpoint that exposes OpenResponses or chat/completions) through a central hub. The system is designed to work seamlessly with the Vercel AI SDK.
+Gambi is a local-first hub for sharing OpenAI-compatible LLM endpoints across a trusted network. It has two explicit planes:
+
+- Management plane: Gambi-native operations for rooms, participants, heartbeats, and room events.
+- Inference plane: OpenAI-compatible room-scoped endpoints for responses, chat completions, and model listing.
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                           GAMBI HUB (HTTP)                              │
-│                                                                             │
-│  HTTP Endpoints:                                                            │
-│  ┌────────────────────────────────────────────────────────────────────┐    │
-│  │ POST   /rooms                    ← Create a room                   │    │
-│  │ GET    /rooms                    ← List all rooms                  │    │
-│  │ POST   /rooms/:code/join         ← Participant registers endpoint  │    │
-│  │ DELETE /rooms/:code/leave/:id    ← Participant leaves              │    │
-│  │ POST   /rooms/:code/health       ← Health check (10s interval)     │    │
-│  │ GET    /rooms/:code/participants ← List participants               │    │
-│  │                                                                    │    │
-│  │ LLM Proxy (Responses-first):                                      │    │
-│  │ POST   /rooms/:code/v1/responses                                 │    │
-│  │ GET    /rooms/:code/v1/responses/:id                             │    │
-│  │ DELETE /rooms/:code/v1/responses/:id                             │    │
-│  │ POST   /rooms/:code/v1/responses/:id/cancel                      │    │
-│  │ GET    /rooms/:code/v1/responses/:id/input_items                 │    │
-│  │ POST   /rooms/:code/v1/chat/completions                          │    │
-│  │ GET    /rooms/:code/v1/models                                    │    │
-│  │                                                                    │    │
-│  │ SSE (for TUI):                                                    │    │
-│  │ GET    /rooms/:code/events                                        │    │
-│  └────────────────────────────────────────────────────────────────────┘    │
-│                                                                             │
-│  Participant Registry (in-memory):                                          │
-│  ┌────────────────────────────────────────────────────────────────────┐    │
-│  │ joao  → { endpoint: "http://192.168.1.50:11434", model, lastSeen } │    │
-│  │ maria → { endpoint: "http://192.168.1.51:1234", model, lastSeen }  │    │
-│  └────────────────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────────────────┘
-           ▲                    ▲                         ▲
-           │ HTTP               │ HTTP                    │ SSE
-           │                    │                         │
-      ┌────┴────┐    ┌─────────┴─────────┐         ┌─────┴─────┐
-      │   SDK   │    │   Participants    │         │    TUI    │
-      └─────────┘    └───────────────────┘         └───────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│                           GAMBI HUB                                │
+│                                                                     │
+│  Management plane (`/v1`)                                          │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ GET    /v1/health                                            │  │
+│  │ GET    /v1/rooms                                             │  │
+│  │ POST   /v1/rooms                                             │  │
+│  │ GET    /v1/rooms/:code                                       │  │
+│  │ GET    /v1/rooms/:code/participants                          │  │
+│  │ PUT    /v1/rooms/:code/participants/:id                      │  │
+│  │ DELETE /v1/rooms/:code/participants/:id                      │  │
+│  │ POST   /v1/rooms/:code/participants/:id/heartbeat            │  │
+│  │ GET    /v1/rooms/:code/events                                │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                     │
+│  Inference plane (`/rooms/:code/v1/*`)                             │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ GET    /rooms/:code/v1/models                                 │  │
+│  │ POST   /rooms/:code/v1/responses                              │  │
+│  │ GET    /rooms/:code/v1/responses/:id                          │  │
+│  │ DELETE /rooms/:code/v1/responses/:id                          │  │
+│  │ POST   /rooms/:code/v1/responses/:id/cancel                   │  │
+│  │ GET    /rooms/:code/v1/responses/:id/input_items              │  │
+│  │ POST   /rooms/:code/v1/chat/completions                       │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+             ▲                      ▲                      ▲
+             │                      │                      │
+             │ management           │ inference            │ live ops
+             │                      │                      │
+      ┌─────────────┐        ┌───────────────┐      ┌─────────────┐
+      │ CLI + SDK   │        │ createGambi() │      │ gambi-tui   │
+      └─────────────┘        └───────────────┘      └─────────────┘
 ```
 
-## Design Philosophy
+## Design goals
 
-Gambi follows the principle of **feature parity across all endpoints**. Each entry point exposes the same core capabilities through an interface optimized for its target use case:
+The redesign intentionally separates the operational and application contracts.
 
-| Endpoint | Target Audience | Use Case |
-|----------|-----------------|----------|
-| **SDK** | Developers | Programmatic integration for JS/TS applications (Vercel AI SDK compatible) |
-| **CLI** | DevOps / Power Users | Scripts, automation, and CI/CD pipelines |
-| **TUI** | Human Operators | Interactive real-time monitoring and management |
+### Management plane goals
 
-### Architecture Pattern
+- predictable machine-readable responses
+- deterministic error envelopes
+- retry-safe participant registration
+- typed event streams
+- stateless operational control
 
-Internally, Gambi follows a **Ports and Adapters** style. The public edge is `OpenResponses-first`, but the hub core does not hardcode that as its only internal shape.
+### Inference plane goals
 
-- The hub defines protocol adapter ports for request creation and stored-response lifecycle operations.
-- `openResponses` and `chatCompletions` are the first concrete adapters registered today.
-- Adapter selection is ordered and explicit: the public `responses` edge tries the `openResponses` adapter first, then falls back to the `chatCompletions` adapter when required.
-- The SDK follows the same pattern through a protocol namespace factory registry, with `openResponses` as the default public protocol.
+- OpenAI-compatible transport
+- compatibility with AI SDK and similar clients
+- room-scoped model routing
 
-This is intentionally close to the “generic interface + interpreter” style you see in systems like Effect: the core talks to capabilities, and concrete protocol behavior lives at the edge.
+## Component roles
 
-### Invocation Pattern
+### `packages/core`
 
-| Command | Result |
-|---------|--------|
-| `gambi` | Shows CLI help |
-| `gambi-tui` | Opens **TUI** - Interactive monitoring and management interface |
-| `gambi serve` | CLI - Starts hub server (scripting) |
-| `gambi create` | CLI - Creates room (scripting) |
-| `gambi join` | CLI - Joins as participant (scripting) |
-| `gambi list` | CLI - Lists rooms (scripting) |
-| `gambi update` | CLI - Updates the current install (bun, npm, or standalone) |
+Source of truth for the hub runtime and HTTP contracts.
 
-**Important:** The standalone CLI shows help when you run `gambi` with no subcommand. The TUI is a separate package: `bun add -g gambi-tui`.
+Key responsibilities:
 
-### Feature Parity Matrix
+- room and participant registry
+- management HTTP handlers
+- inference proxying
+- SSE room events
+- mDNS discovery support
+- shared transport and domain schemas
 
-| Feature | SDK | CLI | TUI |
-|---------|-----|-----|-----|
-| Create room | POST /rooms | `gambi create` | Create dialog |
-| List rooms | GET /rooms | `gambi list` | Room selector |
-| Join room | POST /rooms/:code/join | `gambi join` | Join dialog |
-| Update installed CLI | - | `gambi update` | N/A |
-| Leave room | DELETE /rooms/:code/leave/:id | Auto on exit | Leave action |
-| Health check | POST /rooms/:code/health | Auto (background) | Auto (background) |
-| Responses create | POST /rooms/:code/v1/responses | Via SDK | N/A (monitoring only) |
-| Responses lifecycle | `/rooms/:code/v1/responses/:id*` | HTTP/API clients | N/A (monitoring only) |
-| Chat completion (legacy) | POST /rooms/:code/v1/chat/completions | Via SDK or explicit legacy mode | N/A (monitoring only) |
-| Real-time events | SSE subscription | - | Built-in |
-| Serve hub | - | `gambi serve` | Embedded server |
+Important files:
 
-### Runtime Defaults
+- `packages/core/src/hub.ts`
+- `packages/core/src/room.ts`
+- `packages/core/src/participant.ts`
+- `packages/core/src/sse.ts`
+- `packages/core/src/types.ts`
 
-- Rooms can define runtime defaults when created.
-- Participants can register runtime defaults when they join.
-- The hub merges defaults at proxy time with precedence `room defaults -> participant defaults -> runtime request`.
-- Public room and participant endpoints expose only a redacted summary for sensitive fields such as instructions/system prompts.
+### `packages/cli`
 
-Example:
+Operational CLI for both humans and agents.
 
-- Room sets `instructions = "Answer in Portuguese"` and `temperature = 0.3`
-- Participant joins with `temperature = 0.6`
-- Client sends a request with `temperature = 0.9`
-- Final proxied request uses:
-  - `instructions = "Answer in Portuguese"`
-  - `temperature = 0.9`
+The CLI is resource-oriented:
 
-## Packages
+- `gambi hub serve`
+- `gambi room create|list|get`
+- `gambi participant join|leave|heartbeat`
+- `gambi events watch`
+- `gambi self update`
 
-The project is a Bun + Turbo monorepo with the following packages:
+The CLI is a renderer over the management plane. Human mode uses compact text. Script mode uses JSON or NDJSON.
 
-### `@gambi/core`
+### `packages/sdk`
 
-Core library containing the hub server and shared utilities.
+Split by audience:
 
-**Key files:**
-- `hub.ts` - HTTP server with protocol adapter registry, Responses-first proxy, and legacy chat/completions compatibility
-- `protocol-adapters.ts` - Adapter contracts used by the hub core and SDK exports
-- `room.ts` - Room and participant management
-- `sse.ts` - Server-Sent Events for real-time updates
-- `mdns.ts` - mDNS (Bonjour/Zeroconf) service discovery
-- `types.ts` - Zod schemas and TypeScript types
+- `createGambi()` for inference through the OpenAI-compatible room endpoints
+- `createClient()` for operational control over rooms, participants, and room events
 
-### `gambi`
+The management client maps directly to `/v1` instead of inventing a parallel contract.
 
-Command-line interface for managing hubs and participants.
+### `apps/tui`
 
-**Commands:**
-- `serve` - Start a hub server (with optional `--mdns` flag)
-- `create` - Create a new room, optionally with runtime defaults from JSON
-- `list` - List available rooms
-- `join` - Join a room with your LLM endpoint and optional runtime defaults
+Human-first monitoring interface. It consumes the management plane and room event stream, but remains a separate package from `gambi`.
 
-### `gambi-sdk`
+## Management plane
 
-SDK for integrating with the Vercel AI SDK.
+### Envelope contract
 
-**Installation:**
-```bash
-npm install gambi-sdk
-```
+Every management response is structured:
 
-Available on npm: https://www.npmjs.com/package/gambi-sdk
-
-```typescript
-import { createGambi } from "gambi-sdk";
-import { generateText } from "ai";
-
-const gambi = createGambi({ roomCode: "ABC123" });
-
-// Use any available participant
-const result = await generateText({
-  model: gambi.any(),
-  prompt: "Hello!",
-});
-
-// Use a specific participant by ID
-const result2 = await generateText({
-  model: gambi.participant("participant-id"),
-  prompt: "Hello!",
-});
-
-// Use a specific model type (routes to first participant with that model)
-const result3 = await generateText({
-  model: gambi.model("llama3"),
-  prompt: "Hello!",
-});
-
-const legacy = createGambi({
-  roomCode: "ABC123",
-  defaultProtocol: "chatCompletions",
-});
-
-const result4 = await generateText({
-  model: legacy.any(),
-  prompt: "Legacy chat/completions flow",
-});
-```
-
-For local Node.js/Bun applications, the SDK also exposes optional discovery helpers:
-
-- `discoverHubs()` - find reachable hubs from a configured seed plus mDNS
-- `discoverRooms()` - aggregate rooms across reachable hubs
-- `resolveGambiTarget()` - resolve one room to `{ hubUrl, roomCode }`
-
-These helpers are available from the root export (`gambi-sdk`) or from the dedicated subpath `gambi-sdk/discovery` for a smaller import surface.
-
-These helpers are additive. `createGambi()` and `createClient()` remain explicit and do not perform implicit async discovery.
-
-### `gambi-tui`
-
-Terminal UI for monitoring rooms and participants in real-time (uses SSE). Published as a separate npm package.
-
-**Installation:** `bun add -g gambi-tui`
-**Usage:** `gambi-tui --hub http://localhost:3000`
-
-## Communication Flow
-
-### 1. Participant Registration
-
-```
-Participant                Hub
-    │                       │
-    │  POST /rooms/:code/join
-    │  { id, nickname, model, endpoint, specs, config? }
-    │ ──────────────────────►
-    │                       │
-    │  201 Created          │
-    │  { participant, roomId }
-    │ ◄──────────────────────
-    │                       │
-    │  (every 10 seconds)   │
-    │  POST /rooms/:code/health
-    │  { id }               │
-    │ ──────────────────────►
-    │                       │
-```
-
-### 2. SDK Request Flow
-
-```
-SDK                        Hub                     Participant
- │                          │                           │
- │  POST /rooms/:code/v1/responses                     │
- │  { model: "participant-id", messages, stream }      │
- │ ────────────────────────►│                          │
- │                          │                          │
- │                          │  POST /v1/responses
- │                          │  { model: "llama3", input, stream }
- │                          │ ─────────────────────────►│
- │                          │                          │
- │                          │  SSE Stream / JSON       │
- │                          │ ◄─────────────────────────│
- │                          │                          │
- │  SSE Stream / JSON       │                          │
- │ ◄────────────────────────│                          │
-```
-
-## Model Routing
-
-The SDK supports three ways to select a participant:
-
-| Pattern | Example | Description |
-|---------|---------|-------------|
-| Participant ID | `gambi.participant("abc123")` | Routes to specific participant |
-| Model name | `gambi.model("llama3")` | Routes to first online participant with that model |
-| Any | `gambi.any()` or `model: "*"` | Routes to random online participant |
-
-## Health Checking
-
-- Participants send health checks every **10 seconds** (`HEALTH_CHECK_INTERVAL`)
-- Participants are marked offline after **30 seconds** of no health check (`PARTICIPANT_TIMEOUT = 3 × HEALTH_CHECK_INTERVAL`)
-- The hub broadcasts `participant:offline` events via SSE when a participant times out
-
-## mDNS Discovery
-
-When started with `--mdns`, the hub publishes itself via Bonjour/Zeroconf:
-
-```bash
-gambi serve --mdns
-```
-
-This allows clients on the local network to discover the hub automatically without knowing its IP address.
-
-Service format: `gambi-hub-{port}._gambi._tcp.local`
-
-The SDK builds on top of the same mechanism for local apps through `discoverHubs()`, `discoverRooms()`, and `resolveGambiTarget()`. This keeps the provider/client APIs explicit while still enabling zero-config room selection in TypeScript applications.
-
-## Supported Providers
-
-Any server with OpenResponses or OpenAI-compatible chat/completions:
-
-| Provider | Default Endpoint |
-|----------|-----------------|
-| Ollama | `http://localhost:11434` |
-| LM Studio | `http://localhost:1234` |
-| LocalAI | `http://localhost:8080` |
-| vLLM | `http://localhost:8000` |
-
-## Data Types
-
-### ParticipantInfo
-
-```typescript
+```json
 {
-  id: string;
-  nickname: string;
-  model: string;
-  endpoint: string;  // LLM API base URL
-  config: RuntimeConfigPublic;
-  specs: MachineSpecs;
-  capabilities: {
-    openResponses: "supported" | "unsupported" | "unknown";
-    chatCompletions: "supported" | "unsupported" | "unknown";
-  };
-  status: "online" | "offline" | "busy";
-  joinedAt: number;
-  lastSeen: number;  // Timestamp of last health check
+  "data": {},
+  "meta": {
+    "requestId": "req_123"
+  }
 }
 ```
 
-### RuntimeConfigPublic
+Errors are also structured:
 
-Public room/participant defaults summary:
-
-```typescript
+```json
 {
-  hasInstructions: boolean;
-  temperature?: number;
-  top_p?: number;
-  max_tokens?: number;
-  stop?: string[];
-  frequency_penalty?: number;
-  presence_penalty?: number;
-  seed?: number;
+  "error": {
+    "code": "INVALID_REQUEST",
+    "message": "Participant identifier is required.",
+    "hint": "Pass --participant-id or provide it in the request path."
+  },
+  "meta": {
+    "requestId": "req_456"
+  }
 }
 ```
 
-## Previous Architecture
+`meta.requestId` is part of the public contract and should be preserved by CLI and SDK callers.
 
-The original architecture used WebSocket for all communication. This was replaced with HTTP + SSE for:
+### Room lifecycle
 
-1. **Simpler SDK integration** - Uses `@ai-sdk/open-responses` by default, with explicit legacy `@ai-sdk/openai-compatible` support
-2. **Standard API** - Hub exposes OpenResponses as the primary public protocol and keeps chat/completions for compatibility
-3. **Better debugging** - HTTP requests are easier to inspect and test
-4. **Reduced complexity** - No need to manage WebSocket connections in the SDK
+- Room creation is intentionally non-idempotent.
+- `GET /v1/rooms/:code` exists so clients do not need to list and filter locally.
+- Public room summaries include:
+  - `id`
+  - `code`
+  - `name`
+  - `hostId`
+  - `createdAt`
+  - `participantCount`
+  - `passwordProtected`
+  - `defaults`
 
-The old WebSocket-based plan is preserved in `docs/old/architecture-v1-websocket.md` for reference.
+### Participant lifecycle
+
+Participant registration uses idempotent upsert semantics:
+
+- `PUT /v1/rooms/:code/participants/:id`
+
+Behavior:
+
+- create on first registration
+- return a stable `200` or `201` path for retries
+- update the existing participant when the payload changes
+
+This is the foundation for retry-safe automation and the CLI’s `participant join --participant-id`.
+
+### Heartbeats and liveness
+
+Participants stay online by sending:
+
+- `POST /v1/rooms/:code/participants/:id/heartbeat`
+
+Constants:
+
+- `HEALTH_CHECK_INTERVAL = 10_000`
+- `PARTICIPANT_TIMEOUT = 30_000`
+
+The hub marks inactive participants offline when the timeout window is exceeded.
+
+## Event model
+
+Room events are emitted as SSE with typed JSON payloads.
+
+Each event object contains:
+
+- `type`
+- `timestamp`
+- `roomCode`
+- `data`
+
+Current event types:
+
+- `connected`
+- `room.created`
+- `participant.joined`
+- `participant.updated`
+- `participant.left`
+- `participant.offline`
+- `llm.request`
+- `llm.error`
+
+The CLI converts these directly into NDJSON for `gambi events watch --format ndjson`. The SDK exposes the same shape through `client.events.watchRoom()`.
+
+## Inference plane
+
+The inference plane remains OpenAI-compatible and room-scoped:
+
+- `GET /rooms/:code/v1/models`
+- `POST /rooms/:code/v1/responses`
+- `GET /rooms/:code/v1/responses/:id`
+- `DELETE /rooms/:code/v1/responses/:id`
+- `POST /rooms/:code/v1/responses/:id/cancel`
+- `GET /rooms/:code/v1/responses/:id/input_items`
+- `POST /rooms/:code/v1/chat/completions`
+
+Model routing rules:
+
+- `model = <participant-id>` routes to a specific participant
+- `model = model:<name>` routes to the first online participant matching that model
+- `model = *` or `any` routes to a random online participant
+
+The hub still prefers the Responses API first and keeps chat completions available explicitly.
+
+## Runtime defaults
+
+Rooms and participants can both contribute runtime defaults. At proxy time, the hub merges them in this order:
+
+1. room defaults
+2. participant defaults
+3. request-time overrides
+
+Sensitive config is not exposed raw in public management responses. Public responses expose redacted or summarized values where needed.
+
+## Discovery
+
+Discovery remains useful for local-network applications. The SDK discovery helpers now resolve hubs and rooms against the management plane under `/v1`.
+
+Helpers:
+
+- `discoverHubs()`
+- `discoverRooms()`
+- `resolveGambiTarget()`
+
+These helpers remain explicit. `createGambi()` and `createClient()` do not perform implicit discovery.
+
+## Operational surfaces
+
+### CLI
+
+Optimized for human-readable text and machine-readable JSON/NDJSON.
+
+Important traits:
+
+- flag-first
+- pipe-friendly
+- `--interactive` and `--no-interactive`
+- XDG config support
+- NDJSON on streaming commands when stdout is piped
+
+### SDK management client
+
+Optimized for code-driven operational workflows.
+
+Namespaces:
+
+- `client.rooms.*`
+- `client.participants.*`
+- `client.events.watchRoom()`
+
+### TUI
+
+Optimized for human monitoring. It is not the canonical operational contract.
+
+## Repository map
+
+- `packages/core`: hub runtime and contracts
+- `packages/cli`: operational CLI
+- `packages/sdk`: inference provider and management client
+- `apps/tui`: monitoring interface
+- `apps/docs`: documentation site
+
+## Security model
+
+Gambi is designed for trusted local networks. The hub does not include native authentication. Do not expose it publicly without an external auth and proxy layer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,6 +207,7 @@ Current event types:
 - `participant.left`
 - `participant.offline`
 - `llm.request`
+- `llm.complete`
 - `llm.error`
 
 The CLI converts these directly into NDJSON for `gambi events watch --format ndjson`. The SDK exposes the same shape through `client.events.watchRoom()`.

--- a/docs/plan-agent-first-cli-http-sdk.md
+++ b/docs/plan-agent-first-cli-http-sdk.md
@@ -1,0 +1,557 @@
+# Agent-First Redesign for Gambi CLI, Core HTTP API, and SDK
+
+## Summary
+- Redesign Gambi’s operational surface as an agent-first system across three layers together: CLI, management HTTP API, and SDK.
+- Treat the management plane as a first-class public contract with explicit schemas, typed events, deterministic errors, and retry-safe operations.
+- Keep the inference plane focused on OpenAI-compatible routing for applications, but tighten how it is documented and how the SDK separates inference use cases from operational control use cases.
+- Do not preserve old command names, old management endpoints, or old SDK method shapes for compatibility. This is a deliberate clean break.
+
+## Scope
+- In scope:
+  - `packages/cli`
+  - `packages/core` management HTTP API and event contracts
+  - `packages/sdk` management client and AI SDK provider boundary
+  - `README.md`
+  - `docs/architecture.md`
+  - `apps/docs/src/content/docs/reference/cli.mdx`
+  - `apps/docs/src/content/docs/reference/api.md`
+  - `apps/docs/src/content/docs/reference/sdk.md`
+  - `AGENTS.md` guidance where relevant
+- Out of scope:
+  - adding authentication/authorization
+  - changing the underlying proxy semantics for OpenAI-compatible inference unless required for clearer typing or docs
+  - adding a web UI
+  - folding TUI into the CLI binary
+
+## Product Positioning Decisions
+- `gambi` becomes the operational CLI for humans and agents.
+- `gambi-tui` remains the human-first monitoring interface.
+- The HTTP API exposed by `packages/core/src/hub.ts` is the source of truth for management-plane semantics.
+- The SDK becomes explicitly split by audience:
+  - inference use: `createGambi()` and provider namespaces
+  - operational use: management client and room event watching
+- The CLI must consume the same structured contracts exposed by the management HTTP API instead of inventing ad hoc prose behavior.
+
+## Step 0: Persist This Plan in `docs/`
+- Before implementation work, add this plan to the repo docs as a working design artifact.
+- Canonical file path:
+  - `docs/plan-agent-first-cli-http-sdk.md`
+- The implementation workflow should create the markdown file once, then duplicate it with `cp` only if a second copy is needed elsewhere for review.
+- If a second copy is desired inside the site docs tree for internal visibility, use:
+  - `cp docs/plan-agent-first-cli-http-sdk.md apps/docs/src/content/docs/architecture/agent-first-cli-http-sdk-plan.md`
+- This plan document is an internal engineering artifact, not part of the user-facing reference set unless explicitly linked later.
+
+## Architectural Direction
+
+### 1. Split the surface into two clear planes
+- Management plane:
+  - rooms
+  - participants
+  - health
+  - events
+  - operational status
+  - used by CLI, TUI, and management parts of the SDK
+- Inference plane:
+  - `/v1/models`
+  - `/v1/responses*`
+  - `/v1/chat/completions`
+  - used by SDK provider and external OpenAI-compatible clients
+
+### 2. Make the management plane explicitly machine-oriented
+- Every management response must be structured.
+- Every management error must contain a code, message, and hint.
+- Every long-running operation must have a structured event or lifecycle representation.
+- Every retry-prone operation must be idempotent where that makes operational sense.
+- The CLI should render from these primitives rather than defining its own implicit contract.
+
+### 3. Accept a clean break
+- No command aliases for the old verb-only CLI.
+- No compatibility aliases for old unversioned management routes.
+- No preservation of old SDK client method names if the new API is materially better.
+- Docs should be rewritten to present only the new shape.
+
+## CLI Redesign
+
+## Canonical command structure
+- Replace the current flat verbs with resource-oriented commands:
+  - `gambi hub serve`
+  - `gambi room create`
+  - `gambi room list`
+  - `gambi room get`
+  - `gambi participant join`
+  - `gambi participant leave`
+  - `gambi participant heartbeat`
+  - `gambi events watch`
+  - `gambi self update`
+- Root help should group commands by function:
+  - `Hub`
+  - `Rooms`
+  - `Participants`
+  - `Events`
+  - `Maintenance`
+- Each command help must include:
+  - short description
+  - longer intent description
+  - 3-5 concrete examples
+  - output mode notes when applicable
+
+## Global CLI contract
+- Add global flags:
+  - `--format text|json|ndjson`
+  - `--interactive`
+  - `--no-interactive`
+  - `--env <name>`
+  - `--verbose`
+  - `--quiet`
+- Add global environment variables:
+  - `NO_COLOR=1`
+  - `GAMBI_FORMAT`
+  - `GAMBI_ENV`
+  - `GAMBI_NO_INTERACTIVE=1`
+- Behavioral defaults:
+  - if stdout is a TTY and the command is naturally one-shot, default to `text`
+  - if stdout is piped, default to `json` for one-shot commands
+  - if stdout is piped for a streaming command, default to `ndjson`
+  - if `GAMBI_NO_INTERACTIVE=1` or `--no-interactive` is set, never prompt
+  - if `--interactive` is set, prompting is allowed where the command supports it
+
+## Prompting rules
+- `hub serve` must not auto-prompt when invoked bare; safe defaults are enough.
+- `room list`, `room get`, `events watch`, and `participant heartbeat` must never auto-prompt.
+- `room create` and `participant join` may prompt only when required fields are missing and `--interactive` is in effect or the default interactive policy explicitly allows it on TTY.
+- Interactive mode is a renderer path, not a distinct control path.
+- No command may require arrow-key-based prompt usage to be automatable.
+
+## Output contract
+- `text`:
+  - compact
+  - readable
+  - no unnecessary decoration
+  - no spinner output when piped
+- `json`:
+  - valid JSON object
+  - stable top-level shape
+  - no prose prefix/suffix
+- `ndjson`:
+  - one event per line
+  - each line is a complete JSON object
+  - suitable for agents, pipes, and log processors
+
+## Exit codes
+- `0` success
+- `1` internal/unexpected failure
+- `2` invalid usage or validation error
+- `3` connectivity/auth/dependency failure
+- `4` remote rejection or state conflict
+- These codes must be implemented consistently in the CLI, informed by structured management API errors.
+
+## Command-specific CLI behavior
+
+### `gambi hub serve`
+- Flags:
+  - `--host`
+  - `--port`
+  - `--mdns`
+  - `--dry-run`
+- `--dry-run` prints the resolved startup plan and exits.
+- `--format json` returns resolved host, port, mdns, bind URL, and any warnings.
+- `--format ndjson` for real execution emits:
+  - `started`
+  - `mdns_registered`
+  - `signal_received`
+  - `stopped`
+  - `error`
+- SIGINT and SIGTERM must share a single cleanup path.
+
+### `gambi room create`
+- Flags:
+  - `--name`
+  - `--password`
+  - `--config <path|- >`
+  - `--hub`
+  - `--dry-run`
+- `--config -` reads JSON from stdin.
+- `--dry-run` validates payload and prints the request plan without creating.
+- `--format json` returns the created room envelope from the management API.
+
+### `gambi room list`
+- Flags:
+  - `--hub`
+  - `--sort participant-count|created-at|name`
+  - `--reverse`
+- Never prompt for output format.
+- Default sorting in machine and human mode:
+  - participant count descending
+  - then created date descending
+
+### `gambi room get`
+- Required:
+  - `--code`
+- Returns one room plus metadata like:
+  - participant count
+  - password protected
+  - defaults summary
+
+### `gambi participant join`
+- Flags:
+  - `--room`
+  - `--participant-id`
+  - `--nickname`
+  - `--model`
+  - `--endpoint`
+  - `--network-endpoint`
+  - `--header`
+  - `--header-env`
+  - `--password`
+  - `--config <path|- >`
+  - `--no-specs`
+  - `--dry-run`
+- `--participant-id` is required in strict machine mode and optional in interactive human mode if auto-generation remains allowed.
+- `--dry-run` performs:
+  - endpoint validation
+  - model probe
+  - capability detection
+  - published endpoint resolution
+  - request payload preview
+- Real execution in `ndjson` mode emits:
+  - `prepared`
+  - `registered`
+  - `heartbeat_ok`
+  - `heartbeat_failed`
+  - `leaving`
+  - `left`
+  - `error`
+
+### `gambi participant leave`
+- Explicit leave operation for operational tooling.
+- Flags:
+  - `--room`
+  - `--participant-id`
+- Returns structured success or conflict/error.
+
+### `gambi participant heartbeat`
+- Explicit heartbeat command for scriptability and testing.
+- Flags:
+  - `--room`
+  - `--participant-id`
+- Useful for automation and for testing participant liveness semantics independent of the long-running join process.
+
+### `gambi events watch`
+- Flags:
+  - `--room`
+  - `--hub`
+- `text` mode is human-readable stream.
+- `ndjson` mode mirrors management SSE payloads exactly.
+- This becomes the CLI bridge between operational scripts and real-time room state.
+
+### `gambi self update`
+- Flags:
+  - `--manager`
+  - `--yes`
+  - `--dry-run`
+- `--yes` bypasses confirmation.
+- `--format json` returns the resolved update plan and final result object.
+
+## Core HTTP API Redesign
+
+## Source of truth
+- Confirmed source of truth for management HTTP behavior:
+  - `packages/core/src/hub.ts`
+- Confirmed source of truth for transport/domain schemas:
+  - `packages/core/src/types.ts`
+
+## Canonical management API
+- Define management API under `/v1` only:
+  - `GET /v1/health`
+  - `GET /v1/rooms`
+  - `POST /v1/rooms`
+  - `GET /v1/rooms/:code`
+  - `GET /v1/rooms/:code/participants`
+  - `PUT /v1/rooms/:code/participants/:id`
+  - `DELETE /v1/rooms/:code/participants/:id`
+  - `POST /v1/rooms/:code/participants/:id/heartbeat`
+  - `GET /v1/rooms/:code/events`
+- Remove old management route shapes rather than aliasing them.
+
+## Management response envelopes
+- Standardize on a single transport pattern:
+  - success object: `{ "data": { ... }, "meta": { ... } }`
+  - success list: `{ "data": [...], "meta": { ... } }`
+  - action success: `{ "data": { "success": true, ... }, "meta": { ... } }`
+  - error: `{ "error": { "code": "...", "message": "...", "hint": "...", "details": ... }, "meta": { "requestId": "..." } }`
+- `meta` should include:
+  - `requestId`
+  - optional pagination fields in future
+  - optional timing fields if cheap to compute
+- The CLI and SDK should preserve this information rather than stripping it away prematurely.
+
+## Management error model
+- Add explicit core error codes, for example:
+  - `ROOM_NOT_FOUND`
+  - `PARTICIPANT_NOT_FOUND`
+  - `INVALID_REQUEST`
+  - `INVALID_PASSWORD`
+  - `ENDPOINT_NOT_REACHABLE`
+  - `LOOPBACK_ENDPOINT_FOR_REMOTE_HUB`
+  - `PARTICIPANT_CONFLICT`
+  - `MODEL_NOT_FOUND`
+- Every error should include a machine-usable `code` plus a human-usable `hint`.
+- This is the basis for deterministic CLI exit codes and better SDK exceptions.
+
+## Room model changes
+- Public room summary should include:
+  - `id`
+  - `code`
+  - `name`
+  - `hostId`
+  - `createdAt`
+  - `participantCount`
+  - `passwordProtected`
+  - `defaults`
+- Add `GET /v1/rooms/:code` so clients do not need to list-and-filter.
+- Keep defaults redacted for sensitive data exactly as today, but make the redaction model explicit and documented.
+
+## Participant registration semantics
+- Replace join-style semantics with idempotent upsert:
+  - `PUT /v1/rooms/:code/participants/:id`
+- Behavior:
+  - if absent, create participant and return `201`
+  - if present and materially unchanged, return `200` with same participant representation
+  - if present and changed, update and return `200`
+- This directly supports retries by agents and long-running automation.
+- Add `updatedAt` to public participant shape for event ordering and change detection.
+- Add `registrationState` or equivalent if useful for debugging repeated joins, but do not overcomplicate unless tests show need.
+
+## Heartbeat semantics
+- Use canonical route:
+  - `POST /v1/rooms/:code/participants/:id/heartbeat`
+- Response body includes:
+  - `success`
+  - `status`
+  - `lastSeen`
+- This is a cleaner and more self-describing route than posting a body with `{ id }`.
+
+## Leave semantics
+- Use canonical route:
+  - `DELETE /v1/rooms/:code/participants/:id`
+- Response should be structured and deterministic:
+  - success returns `200`
+  - not found returns structured `404`
+- This operation must be safe to call during cleanup and retries.
+
+## Event stream contract
+- Formalize SSE payloads in core.
+- Each SSE event line should carry a JSON object with:
+  - `type`
+  - `timestamp`
+  - `roomCode`
+  - `data`
+- Event types:
+  - `connected`
+  - `room.created`
+  - `participant.joined`
+  - `participant.updated`
+  - `participant.left`
+  - `participant.offline`
+- Ensure the SSE helper in `packages/core/src/sse.ts` only emits this typed event contract.
+- The CLI `events watch --format ndjson` should relay these objects directly, not reinterpret them.
+
+## Discovery implications
+- Discovery remains useful primarily for human and LAN-hosted workflows.
+- The discovery layer in core can stay mostly as-is, but should consume the new management endpoints and envelopes:
+  - `GET /v1/health`
+  - `GET /v1/rooms`
+- Discovery errors should remain typed and machine-usable.
+
+## Inference plane adjustments
+- Keep inference endpoints compatible and focused:
+  - `/rooms/:code/v1/models`
+  - `/rooms/:code/v1/responses*`
+  - `/rooms/:code/v1/chat/completions`
+- Do not wrap these in the management envelope because they need to remain OpenAI-compatible.
+- Do tighten docs so the distinction is explicit:
+  - management plane has Gambi-native contracts
+  - inference plane is OpenAI-compatible transport
+
+## Core types and schema work
+
+## New transport types in `packages/core/src/types.ts`
+- Add:
+  - `ApiMeta`
+  - `ApiErrorShape`
+  - `ApiSuccess<T>`
+  - `ApiErrorResponse`
+  - `RoomSummary`
+  - `ParticipantSummary`
+  - `RoomEvent`
+  - `RoomEventType`
+- Keep domain types separate from transport wrappers.
+- Public room and participant transport types should be intentionally documented as stable contracts.
+
+## Participant and room transport shape updates
+- Room transport:
+  - add `participantCount`
+  - add `passwordProtected`
+- Participant transport:
+  - add `updatedAt`
+  - keep redacted config summary
+  - keep capability summary
+- Make sure the internal-to-public conversion logic is centralized rather than duplicated between handlers.
+
+## SDK Redesign
+
+## SDK audience split
+- `createGambi()` stays the inference-focused entry point for app developers using AI SDK.
+- Add a clearer management client surface for apps and tools that need operational control.
+- Document the rule of thumb:
+  - use `createGambi()` when your app wants to send model requests
+  - use the management client when your app wants to create rooms, register participants, inspect state, or watch events
+
+## Management client shape
+- Replace the current flat `createClient()` method set with namespaced operations:
+  - `client.rooms.create(...)`
+  - `client.rooms.list(...)`
+  - `client.rooms.get(...)`
+  - `client.participants.upsert(...)`
+  - `client.participants.list(...)`
+  - `client.participants.remove(...)`
+  - `client.participants.heartbeat(...)`
+  - `client.events.watchRoom(...)`
+- These methods should return structured responses or typed domain objects consistently, with documented metadata handling.
+
+## SDK error model
+- Upgrade `ClientError` to include:
+  - `status`
+  - `code`
+  - `hint`
+  - `details`
+  - `requestId`
+- Parse these fields from the new management error envelopes.
+- This makes application-level retries and user guidance much easier.
+
+## SDK event watching
+- Add typed room event watching:
+  - async iterator or callback-based API
+- Example target shape:
+  - `for await (const event of client.events.watchRoom({ roomCode })) { ... }`
+- Event payloads should mirror core `RoomEvent` exactly.
+- This gives application developers a clean operational surface without scraping SSE manually.
+
+## SDK provider boundary
+- Keep `createGambi()` and protocol namespaces intact conceptually:
+  - `participant(id)`
+  - `model(name)`
+  - `any()`
+  - `openResponses`
+  - `chatCompletions`
+- Review `listModels()` and `listParticipants()` so their return types are consistent with the new management and inference contracts.
+- If `listParticipants()` stays on the provider, make sure it consumes the new management endpoint and preserves typed error semantics.
+
+## Documentation Plan
+
+## User-facing docs
+- Update `README.md`:
+  - present the new command structure only
+  - explain the split between CLI and TUI
+  - add examples for JSON and NDJSON usage
+  - add examples for `participant join --dry-run`
+- Update `docs/architecture.md`:
+  - explicitly separate management plane and inference plane
+  - document the role of CLI, SDK, and TUI against these planes
+- Update `apps/docs/src/content/docs/reference/cli.mdx`:
+  - rewrite around the new command tree
+  - remove stale `gambi monitor`
+  - document output modes, stdin config, and machine usage
+- Update `apps/docs/src/content/docs/reference/api.md`:
+  - define canonical `/v1` management API
+  - define response envelopes and error schema
+  - define room event schema
+  - separately document inference routes
+- Update `apps/docs/src/content/docs/reference/sdk.md`:
+  - explain inference provider vs management client
+  - document event watching and typed errors
+
+## Agent guidance docs
+- Update root `AGENTS.md` and any CLI-local instructions as needed to state:
+  - the management API is canonical for operational automation
+  - CLI must remain flag-first and structured-output friendly
+  - SDK management surface should map directly to core contracts
+  - compatibility is not a constraint for this redesign
+
+## Testing Strategy
+
+## Core tests
+- Route coverage for every management endpoint under `/v1`
+- Envelope shape tests for:
+  - success object
+  - success list
+  - error response
+- Participant upsert tests:
+  - create
+  - retry same payload
+  - update changed nickname/config/capabilities
+- Heartbeat tests:
+  - success
+  - missing participant
+  - stale/offline transitions
+- SSE tests:
+  - event names
+  - payload schema
+  - room scoping
+  - offline event emission
+- Discovery tests adjusted to new `/v1` routes and envelopes
+
+## SDK tests
+- Management client method tests for each namespace
+- `ClientError` parsing tests
+- Event watching tests over typed SSE payloads
+- Provider regression tests for inference routes and protocol selection
+- Discovery tests if helper signatures or transport assumptions change
+
+## CLI tests
+- Root help and subcommand help snapshots
+- TTY vs piped stdout behavior
+- `--format text|json|ndjson`
+- `--interactive` and `--no-interactive`
+- `--config -` stdin ingestion
+- deterministic exit code mapping from structured errors
+- `participant join --dry-run`
+- `participant join` retry behavior with explicit `--participant-id`
+- `events watch --format ndjson`
+
+## Acceptance Criteria
+- A script or agent can perform all operational workflows without prompts:
+  - start hub
+  - create room
+  - inspect room
+  - register participant
+  - heartbeat participant
+  - remove participant
+  - watch events
+  - update installation plan
+- Every management command has stable JSON or NDJSON output.
+- Every management HTTP endpoint has a documented envelope and typed error model.
+- The SDK provides a first-class management client and a separate inference provider story.
+- The docs no longer describe stale commands or mixed contracts.
+- The implementation contains no fallback compatibility layers for the old CLI or old management endpoints.
+
+## Implementation Order
+1. Persist this plan to `docs/plan-agent-first-cli-http-sdk.md`, and if desired duplicate it into the docs site tree with `cp`.
+2. Define transport envelopes, error schemas, and typed room events in `packages/core/src/types.ts`.
+3. Refactor management handlers in `packages/core/src/hub.ts` onto the new `/v1` API shape.
+4. Implement participant upsert, canonical heartbeat, room detail endpoint, and typed SSE event payloads.
+5. Update discovery in core to use the new management routes and envelopes.
+6. Redesign the SDK management client around namespaces, typed errors, and room event watching.
+7. Align `createGambi()`-related helper methods with the new management contracts where needed.
+8. Rebuild the CLI on top of the new management API contracts and output modes.
+9. Rewrite README and reference docs to match the new architecture and command tree.
+10. Add or update tests across core, SDK, and CLI until the new contracts are locked.
+
+## Assumptions and Defaults
+- A clean break is acceptable; no compatibility layer is required.
+- The management API is Gambi-native and versioned under `/v1`.
+- The inference API remains OpenAI-compatible and is documented separately from management.
+- `room create` remains non-idempotent by design.
+- `participant` registration becomes idempotent by design.
+- JSON remains the config format in this pass; YAML is not introduced.
+- TUI remains a separate package and is not folded into this redesign.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -170,6 +170,7 @@ node ./packages/cli/dist/npm/gambi/bin/gambi --help
 ## Rules for Everyday Development
 
 - Do not bump versions manually in feature PRs.
+- Use Conventional Commits for new commits whenever possible, for example `fix(cli): harden self update output`.
 - Let the release workflow update synchronized versions.
 - Treat `packages/cli/dist` as generated output only.
 - If a change affects install, publish, wrapper resolution, or platform binaries, update this document and `AGENTS.md` in the same PR.

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "bun run --cwd packages/cli src/cli.ts serve",
-    "dev:hub": "bun run --cwd packages/cli src/cli.ts serve",
+    "dev": "bun run --cwd packages/cli dev -- hub serve",
+    "dev:hub": "bun run --cwd packages/cli dev -- hub serve",
+    "dev:cli": "bun run --cwd packages/cli dev --",
     "dev:tui": "bun run --cwd apps/tui src/index.tsx",
-    "dev:monitor": "bun run --cwd packages/cli src/cli.ts monitor",
+    "dev:monitor": "bun run --cwd apps/tui dev",
     "dev:docs": "turbo -F docs dev",
     "build": "turbo build",
     "check-types": "turbo check-types"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env bun
 import { readFileSync } from "node:fs";
-import { CreateCommand } from "./commands/create.ts";
-import { JoinCommand } from "./commands/join.ts";
-import { ListCommand } from "./commands/list.ts";
-import { ServeCommand } from "./commands/serve.ts";
-import { UpdateCommand } from "./commands/update.ts";
+import { EventsWatchCommand } from "./commands/events-watch.ts";
+import { HubServeCommand } from "./commands/hub-serve.ts";
+import { ParticipantHeartbeatCommand } from "./commands/participant-heartbeat.ts";
+import { ParticipantJoinCommand } from "./commands/participant-join.ts";
+import { ParticipantLeaveCommand } from "./commands/participant-leave.ts";
+import { RoomCreateCommand } from "./commands/room-create.ts";
+import { RoomGetCommand } from "./commands/room-get.ts";
+import { RoomListCommand } from "./commands/room-list.ts";
+import { SelfUpdateCommand } from "./commands/self-update.ts";
 import { Builtins, Cli } from "./utils/option.ts";
 
 function resolveCliVersion() {
@@ -23,26 +27,61 @@ function resolveCliVersion() {
   }
 }
 
+function renderRootHelp() {
+  return [
+    "gambi",
+    "",
+    "Operational CLI for Gambi hubs, rooms, participants, and events.",
+    "",
+    "Hub:",
+    "  gambi hub serve              Start the hub server",
+    "",
+    "Rooms:",
+    "  gambi room create            Create a room",
+    "  gambi room list              List room summaries",
+    "  gambi room get               Get one room summary",
+    "",
+    "Participants:",
+    "  gambi participant join       Register a participant and keep heartbeats alive",
+    "  gambi participant leave      Remove a participant",
+    "  gambi participant heartbeat  Send one participant heartbeat",
+    "",
+    "Events:",
+    "  gambi events watch           Stream room events",
+    "",
+    "Maintenance:",
+    "  gambi self update            Update the installed CLI",
+    "",
+    "Use `gambi <group> <command> --help` for examples and flags.",
+    "Use `gambi-tui` for the human-first terminal dashboard.",
+    "",
+  ].join("\n");
+}
+
 const cli = new Cli({
   binaryLabel: "gambi",
   binaryName: "gambi",
   binaryVersion: resolveCliVersion(),
 });
 
-cli.register(ServeCommand);
-cli.register(CreateCommand);
-cli.register(JoinCommand);
-cli.register(ListCommand);
-cli.register(UpdateCommand);
+cli.register(HubServeCommand);
+cli.register(RoomCreateCommand);
+cli.register(RoomListCommand);
+cli.register(RoomGetCommand);
+cli.register(ParticipantJoinCommand);
+cli.register(ParticipantLeaveCommand);
+cli.register(ParticipantHeartbeatCommand);
+cli.register(EventsWatchCommand);
+cli.register(SelfUpdateCommand);
 cli.register(Builtins.HelpCommand);
 cli.register(Builtins.VersionCommand);
 
 const args = process.argv.slice(2);
-if (args.length === 0) {
-  process.stdout.write(cli.usage());
-  process.stdout.write(
-    "\nFor real-time monitoring, install the TUI: bun add -g gambi-tui\n"
-  );
+if (
+  args.length === 0 ||
+  (args.length === 1 && (args[0] === "--help" || args[0] === "-h"))
+) {
+  process.stdout.write(renderRootHelp());
 } else {
   cli.runExit(args);
 }

--- a/packages/cli/src/commands/events-watch.ts
+++ b/packages/cli/src/commands/events-watch.ts
@@ -1,0 +1,54 @@
+import type { RoomEvent } from "@gambi/core/types";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
+import { watchRoomEvents } from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+function renderEvent(event: RoomEvent): string {
+  return `${new Date(event.timestamp).toISOString()} ${event.type} ${JSON.stringify(event.data)}`;
+}
+
+export class EventsWatchCommand extends AgentCommand {
+  static override paths = [["events", "watch"]];
+
+  static override usage = Command.Usage({
+    description: "Watch room events from the management API",
+    details:
+      "Streams typed room events. Use --format ndjson for agents and log processors.",
+    examples: [
+      ["Watch room events", "gambi events watch --room ABC123"],
+      [
+        "Watch as NDJSON",
+        "gambi events watch --room ABC123 --format ndjson",
+      ],
+    ],
+  });
+
+  room = Option.String("--room,-r", {
+    description: "Room code",
+    required: true,
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const format = this.resolveFormat(true);
+
+    for await (const event of watchRoomEvents(hubUrl, this.room)) {
+      if (format === "text") {
+        this.context.stdout.write(`${renderEvent(event)}\n`);
+      } else {
+        writeStructured(this.context.stdout, format, event);
+      }
+    }
+
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/events-watch.ts
+++ b/packages/cli/src/commands/events-watch.ts
@@ -1,7 +1,11 @@
 import type { RoomEvent } from "@gambi/core/types";
 import { AgentCommand } from "../utils/agent-command.ts";
-import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
-import { watchRoomEvents } from "../utils/management-api.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  WatchRoomEventsError,
+  watchRoomEvents,
+} from "../utils/management-api.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
 
@@ -18,10 +22,7 @@ export class EventsWatchCommand extends AgentCommand {
       "Streams typed room events. Use --format ndjson for agents and log processors.",
     examples: [
       ["Watch room events", "gambi events watch --room ABC123"],
-      [
-        "Watch as NDJSON",
-        "gambi events watch --room ABC123 --format ndjson",
-      ],
+      ["Watch as NDJSON", "gambi events watch --room ABC123 --format ndjson"],
     ],
   });
 
@@ -36,17 +37,32 @@ export class EventsWatchCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
     const format = this.resolveFormat(true);
 
-    for await (const event of watchRoomEvents(hubUrl, this.room)) {
-      if (format === "text") {
-        this.context.stdout.write(`${renderEvent(event)}\n`);
-      } else {
-        writeStructured(this.context.stdout, format, event);
+    try {
+      for await (const event of watchRoomEvents(hubUrl, this.room)) {
+        if (format === "text") {
+          this.context.stdout.write(`${renderEvent(event)}\n`);
+        } else {
+          writeStructured(this.context.stdout, format, event);
+        }
       }
+    } catch (error) {
+      if (error instanceof WatchRoomEventsError) {
+        this.context.stderr.write(renderFailure(error.failure));
+        return exitCodeForFailure(error.failure);
+      }
+
+      this.context.stderr.write(
+        `Error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      return 1;
     }
 
     return 0;

--- a/packages/cli/src/commands/hub-serve.test.ts
+++ b/packages/cli/src/commands/hub-serve.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { parseServePort } from "./hub-serve.ts";
+
+describe("hub serve port parsing", () => {
+  test("accepts valid integer ports", () => {
+    expect(parseServePort("3000")).toBe(3000);
+    expect(parseServePort(65_535)).toBe(65_535);
+  });
+
+  test("rejects invalid port values", () => {
+    expect(parseServePort("abc")).toBeNull();
+    expect(parseServePort("0")).toBeNull();
+    expect(parseServePort("65536")).toBeNull();
+    expect(parseServePort("42.5")).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/hub-serve.ts
+++ b/packages/cli/src/commands/hub-serve.ts
@@ -1,0 +1,110 @@
+import { createHub } from "@gambi/core/hub";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+export class HubServeCommand extends AgentCommand {
+  static override paths = [["hub", "serve"]];
+
+  static override usage = Command.Usage({
+    description: "Start the hub management and inference server",
+    details:
+      "Starts the Gambi hub. Prefer --format ndjson for machine supervision and --dry-run for startup validation.",
+    examples: [
+      ["Start the hub", "gambi hub serve"],
+      ["Preview startup", "gambi hub serve --dry-run --format json"],
+      ["Enable mDNS", "gambi hub serve --mdns"],
+    ],
+  });
+
+  host = Option.String("--host", {
+    description: "Host to bind to",
+    required: false,
+  });
+
+  port = Option.String("--port", {
+    description: "Port to bind to",
+    required: false,
+  });
+
+  mdns = Option.Boolean("--mdns", false, {
+    description: "Enable mDNS discovery",
+  });
+
+  dryRun = Option.Boolean("--dry-run", false, {
+    description: "Print the resolved startup plan and exit",
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const host = this.host ?? envConfig?.serve?.host ?? "0.0.0.0";
+    const port = Number(this.port ?? envConfig?.serve?.port ?? 3000);
+    const mdns = this.mdns || envConfig?.serve?.mdns || false;
+    const format = this.resolveFormat(true);
+    const startupPlan = { host, port, mdns, bindUrl: `http://${host}:${port}` };
+
+    if (this.dryRun) {
+      if (format === "text") {
+        this.context.stdout.write(
+          `Would start hub on ${startupPlan.bindUrl} (mdns: ${mdns ? "enabled" : "disabled"}).\n`
+        );
+      } else {
+        writeStructured(this.context.stdout, format, startupPlan);
+      }
+      return 0;
+    }
+
+    const hub = createHub({ hostname: host, port, mdns });
+
+    if (format === "text") {
+      this.context.stdout.write(`Hub started at ${hub.url}\n`);
+      this.context.stdout.write("Press Ctrl+C to stop\n");
+    } else {
+      writeStructured(this.context.stdout, "ndjson", {
+        type: "started",
+        timestamp: Date.now(),
+        data: {
+          ...startupPlan,
+          hubUrl: hub.url,
+        },
+      });
+      if (hub.mdnsName) {
+        writeStructured(this.context.stdout, "ndjson", {
+          type: "mdns_registered",
+          timestamp: Date.now(),
+          data: { name: hub.mdnsName },
+        });
+      }
+    }
+
+    await new Promise<number>((resolve) => {
+      const shutdown = (signal: string) => {
+        if (format === "text") {
+          this.context.stdout.write(`Shutting down (${signal})...\n`);
+        } else {
+          writeStructured(this.context.stdout, "ndjson", {
+            type: "signal_received",
+            timestamp: Date.now(),
+            data: { signal },
+          });
+        }
+        hub.close();
+        if (format !== "text") {
+          writeStructured(this.context.stdout, "ndjson", {
+            type: "stopped",
+            timestamp: Date.now(),
+            data: { signal },
+          });
+        }
+        resolve(0);
+      };
+
+      process.once("SIGINT", () => shutdown("SIGINT"));
+      process.once("SIGTERM", () => shutdown("SIGTERM"));
+    });
+
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/hub-serve.ts
+++ b/packages/cli/src/commands/hub-serve.ts
@@ -1,6 +1,5 @@
 import { createHub } from "@gambi/core/hub";
 import { AgentCommand } from "../utils/agent-command.ts";
-import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
 
@@ -13,7 +12,7 @@ export class HubServeCommand extends AgentCommand {
       "Starts the Gambi hub. Prefer --format ndjson for machine supervision and --dry-run for startup validation.",
     examples: [
       ["Start the hub", "gambi hub serve"],
-      ["Preview startup", "gambi hub serve --dry-run --format json"],
+      ["Preview startup", "gambi hub serve --dry-run --format ndjson"],
       ["Enable mDNS", "gambi hub serve --mdns"],
     ],
   });
@@ -37,11 +36,14 @@ export class HubServeCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const host = this.host ?? envConfig?.serve?.host ?? "0.0.0.0";
     const port = Number(this.port ?? envConfig?.serve?.port ?? 3000);
-    const mdns = this.mdns || envConfig?.serve?.mdns || false;
+    const mdns = this.mdns || envConfig?.serve?.mdns;
     const format = this.resolveFormat(true);
     const startupPlan = { host, port, mdns, bindUrl: `http://${host}:${port}` };
 
@@ -62,7 +64,7 @@ export class HubServeCommand extends AgentCommand {
       this.context.stdout.write(`Hub started at ${hub.url}\n`);
       this.context.stdout.write("Press Ctrl+C to stop\n");
     } else {
-      writeStructured(this.context.stdout, "ndjson", {
+      writeStructured(this.context.stdout, format, {
         type: "started",
         timestamp: Date.now(),
         data: {
@@ -71,7 +73,7 @@ export class HubServeCommand extends AgentCommand {
         },
       });
       if (hub.mdnsName) {
-        writeStructured(this.context.stdout, "ndjson", {
+        writeStructured(this.context.stdout, format, {
           type: "mdns_registered",
           timestamp: Date.now(),
           data: { name: hub.mdnsName },
@@ -84,7 +86,7 @@ export class HubServeCommand extends AgentCommand {
         if (format === "text") {
           this.context.stdout.write(`Shutting down (${signal})...\n`);
         } else {
-          writeStructured(this.context.stdout, "ndjson", {
+          writeStructured(this.context.stdout, format, {
             type: "signal_received",
             timestamp: Date.now(),
             data: { signal },
@@ -92,7 +94,7 @@ export class HubServeCommand extends AgentCommand {
         }
         hub.close();
         if (format !== "text") {
-          writeStructured(this.context.stdout, "ndjson", {
+          writeStructured(this.context.stdout, format, {
             type: "stopped",
             timestamp: Date.now(),
             data: { signal },

--- a/packages/cli/src/commands/hub-serve.ts
+++ b/packages/cli/src/commands/hub-serve.ts
@@ -3,6 +3,15 @@ import { AgentCommand } from "../utils/agent-command.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
 
+export function parseServePort(input: string | number): number | null {
+  const port = Number(input);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    return null;
+  }
+
+  return port;
+}
+
 export class HubServeCommand extends AgentCommand {
   static override paths = [["hub", "serve"]];
 
@@ -42,7 +51,14 @@ export class HubServeCommand extends AgentCommand {
     }
     const envConfig = envConfigResult.value;
     const host = this.host ?? envConfig?.serve?.host ?? "0.0.0.0";
-    const port = Number(this.port ?? envConfig?.serve?.port ?? 3000);
+    const rawPort = this.port ?? envConfig?.serve?.port ?? 3000;
+    const port = parseServePort(rawPort);
+    if (port === null) {
+      this.context.stderr.write(
+        `Error: Invalid port '${String(rawPort)}'.\nHint: pass an integer between 1 and 65535.\n`
+      );
+      return 2;
+    }
     const mdns = this.mdns || envConfig?.serve?.mdns;
     const format = this.resolveFormat(true);
     const startupPlan = { host, port, mdns, bindUrl: `http://${host}:${port}` };

--- a/packages/cli/src/commands/participant-heartbeat.ts
+++ b/packages/cli/src/commands/participant-heartbeat.ts
@@ -1,0 +1,68 @@
+import type { HeartbeatResult } from "@gambi/core/types";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+export class ParticipantHeartbeatCommand extends AgentCommand {
+  static override paths = [["participant", "heartbeat"]];
+
+  static override usage = Command.Usage({
+    description: "Send one participant heartbeat",
+    details:
+      "Useful for automation and testing participant liveness independently from the long-running join command.",
+    examples: [
+      [
+        "Send a heartbeat",
+        "gambi participant heartbeat --room ABC123 --participant-id worker-1",
+      ],
+    ],
+  });
+
+  room = Option.String("--room,-r", {
+    description: "Room code",
+  });
+
+  participantId = Option.String("--participant-id", {
+    description: "Participant identifier",
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const format = this.resolveFormat(false);
+
+    const response = await requestManagement<HeartbeatResult>(
+      hubUrl,
+      `/v1/rooms/${this.room}/participants/${this.participantId}/heartbeat`,
+      { method: "POST" }
+    );
+
+    if (!response.ok) {
+      this.context.stderr.write(renderFailure(response.value));
+      return exitCodeForFailure(response.value);
+    }
+
+    if (format !== "text") {
+      writeStructured(this.context.stdout, format, response.value);
+      return 0;
+    }
+
+    const heartbeat = response.value.data;
+    this.context.stdout.write(
+      `Heartbeat ok for ${this.participantId} (${heartbeat.status}).\n`
+    );
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/participant-heartbeat.ts
+++ b/packages/cli/src/commands/participant-heartbeat.ts
@@ -1,6 +1,5 @@
 import type { HeartbeatResult } from "@gambi/core/types";
 import { AgentCommand } from "../utils/agent-command.ts";
-import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
 import {
   exitCodeForFailure,
   renderFailure,
@@ -38,8 +37,11 @@ export class ParticipantHeartbeatCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
     const format = this.resolveFormat(false);
 

--- a/packages/cli/src/commands/participant-join.test.ts
+++ b/packages/cli/src/commands/participant-join.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePublishedEndpoint } from "./participant-join.ts";
+
+describe("participant join endpoint validation", () => {
+  test("rejects an invalid published network endpoint", () => {
+    expect(() =>
+      resolvePublishedEndpoint(
+        "http://192.168.1.10:3000",
+        "http://localhost:11434",
+        "not-a-url"
+      )
+    ).toThrow("Invalid --network-endpoint URL: not-a-url.");
+  });
+
+  test("rejects an invalid local endpoint before LAN rewriting", () => {
+    expect(() =>
+      resolvePublishedEndpoint("http://192.168.1.10:3000", "not-a-url")
+    ).toThrow("Invalid endpoint URL: not-a-url.");
+  });
+});

--- a/packages/cli/src/commands/participant-join.test.ts
+++ b/packages/cli/src/commands/participant-join.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { resolvePublishedEndpoint } from "./participant-join.ts";
+import {
+  parseHeaderAssignment,
+  resolvePublishedEndpoint,
+} from "./participant-join.ts";
 
 describe("participant join endpoint validation", () => {
   test("rejects an invalid published network endpoint", () => {
@@ -16,5 +19,14 @@ describe("participant join endpoint validation", () => {
     expect(() =>
       resolvePublishedEndpoint("http://192.168.1.10:3000", "not-a-url")
     ).toThrow("Invalid endpoint URL: not-a-url.");
+  });
+
+  test("rejects header assignments with empty trimmed parts", () => {
+    expect(() => parseHeaderAssignment(" Authorization=   ")).toThrow(
+      "Invalid header assignment ' Authorization=   '. Use Header=Value."
+    );
+    expect(() => parseHeaderAssignment(" =value")).toThrow(
+      "Invalid header assignment ' =value'. Use Header=Value."
+    );
   });
 });

--- a/packages/cli/src/commands/participant-join.ts
+++ b/packages/cli/src/commands/participant-join.ts
@@ -1,0 +1,473 @@
+import {
+  password as passwordPrompt,
+  select,
+  text,
+} from "@clack/prompts";
+import { probeEndpoint } from "@gambi/core/endpoint";
+import { HEALTH_CHECK_INTERVAL, type ParticipantAuthHeaders } from "@gambi/core/types";
+import { nanoid } from "nanoid";
+import {
+  isLoopbackLikeHost,
+  isRemoteHubUrl,
+  listNetworkCandidates,
+  rankNetworkCandidatesForHub,
+  replaceEndpointHost,
+} from "../utils/network-endpoint.ts";
+import { AgentCommand } from "../utils/agent-command.ts";
+import {
+  loadCliConfig,
+  loadRuntimeConfigFromInput,
+  resolveEnvConfig,
+} from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+import { detectSpecs } from "../utils/specs.ts";
+
+function parseHeaderAssignment(input: string): { name: string; value: string } {
+  const index = input.indexOf("=");
+  if (index <= 0 || index === input.length - 1) {
+    throw new Error(
+      `Invalid header assignment '${input}'. Use Header=Value.`
+    );
+  }
+
+  return {
+    name: input.slice(0, index).trim(),
+    value: input.slice(index + 1).trim(),
+  };
+}
+
+function resolveAuthHeaders(
+  headers: string[],
+  headerEnv: string[],
+  envHeaders?: Record<string, string>
+): ParticipantAuthHeaders {
+  const authHeaders: ParticipantAuthHeaders = { ...(envHeaders ?? {}) };
+
+  for (const assignment of headers) {
+    const { name, value } = parseHeaderAssignment(assignment);
+    authHeaders[name] = value;
+  }
+
+  for (const assignment of headerEnv) {
+    const { name, value } = parseHeaderAssignment(assignment);
+    const envValue = process.env[value];
+    if (!envValue) {
+      throw new Error(
+        `Environment variable '${value}' is required for header '${name}'.`
+      );
+    }
+    authHeaders[name] = envValue;
+  }
+
+  return authHeaders;
+}
+
+function resolvePublishedEndpoint(
+  hubUrl: string,
+  endpoint: string,
+  explicitNetworkEndpoint?: string
+): string {
+  if (explicitNetworkEndpoint) {
+    return new URL(explicitNetworkEndpoint).toString();
+  }
+
+  if (!isRemoteHubUrl(hubUrl)) {
+    return endpoint;
+  }
+
+  const hostname = new URL(endpoint).hostname;
+  if (!isLoopbackLikeHost(hostname)) {
+    return endpoint;
+  }
+
+  const rankedCandidates = rankNetworkCandidatesForHub(
+    hubUrl,
+    listNetworkCandidates()
+  );
+  const publishedEndpoints = rankedCandidates.map((candidate) =>
+    replaceEndpointHost(endpoint, candidate.address)
+  );
+
+  if (publishedEndpoints.length === 0) {
+    throw new Error(
+      "Remote hub detected, but no LAN endpoint could be inferred. Pass --network-endpoint."
+    );
+  }
+
+  return publishedEndpoints[0] ?? endpoint;
+}
+
+export class ParticipantJoinCommand extends AgentCommand {
+  static override paths = [["participant", "join"]];
+
+  static override usage = Command.Usage({
+    description: "Register a participant and keep heartbeats alive",
+    details:
+      "Probes the local endpoint, registers the participant through the management API, and keeps sending heartbeats until interrupted.",
+    examples: [
+      [
+        "Join a room",
+        "gambi participant join --room ABC123 --participant-id worker-1 --model llama3",
+      ],
+      [
+        "Preview the registration",
+        "gambi participant join --room ABC123 --participant-id worker-1 --model llama3 --dry-run --format json",
+      ],
+      [
+        "Register against a remote hub",
+        "gambi participant join --room ABC123 --participant-id worker-1 --model llama3 --hub http://192.168.1.10:3000 --network-endpoint http://192.168.1.25:11434",
+      ],
+    ],
+  });
+
+  room = Option.String("--room,-r", {
+    description: "Room code",
+    required: false,
+  });
+
+  participantId = Option.String("--participant-id", {
+    description: "Stable participant identifier",
+    required: false,
+  });
+
+  nickname = Option.String("--nickname,-n", {
+    description: "Display name",
+    required: false,
+  });
+
+  model = Option.String("--model,-m", {
+    description: "Model to expose",
+    required: false,
+  });
+
+  endpoint = Option.String("--endpoint,-e", {
+    description: "Local endpoint used for probing and inference",
+    required: false,
+  });
+
+  networkEndpoint = Option.String("--network-endpoint", {
+    description: "Network-reachable URL to publish to the hub",
+    required: false,
+  });
+
+  headers = Option.Array("--header", [], {
+    description: "Auth header in the format Header=Value",
+  });
+
+  headerEnv = Option.Array("--header-env", [], {
+    description: "Auth header in the format Header=ENV_VAR",
+  });
+
+  password = Option.String("--password,-p", {
+    description: "Room password",
+    required: false,
+  });
+
+  configPath = Option.String("--config", {
+    description: "Runtime config JSON file or '-' for stdin",
+    required: false,
+  });
+
+  noSpecs = Option.Boolean("--no-specs", false, {
+    description: "Do not collect machine specs",
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  dryRun = Option.Boolean("--dry-run", false, {
+    description: "Validate registration inputs and exit",
+  });
+
+  async execute(): Promise<number> {
+    const cliConfig = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(cliConfig, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const endpoint = this.endpoint ?? envConfig?.endpoint ?? "http://localhost:11434";
+    const format = this.resolveFormat(true);
+
+    let room = this.room;
+    let model = this.model;
+    let password = this.password;
+    let nickname = this.nickname;
+    let participantId = this.participantId;
+
+    if (this.allowInteractive(true)) {
+      if (!room) {
+        room = String(await text({ message: "Room code:" })).trim();
+      }
+
+      if (!participantId) {
+        participantId = String(
+          await text({ message: "Participant ID:", placeholder: nanoid(8) })
+        ).trim();
+      }
+
+      if (!model) {
+        const probe = await probeEndpoint(endpoint, {
+          authHeaders: resolveAuthHeaders(
+            this.headers,
+            this.headerEnv,
+            envConfig?.headers
+          ),
+        });
+        if (probe.models.length === 0) {
+          this.context.stderr.write(
+            "Error: No models found on the endpoint.\nHint: verify the local endpoint and retry.\n"
+          );
+          return 3;
+        }
+        model = String(
+          await select({
+            message: "Model:",
+            options: probe.models.map((candidate) => ({
+              value: candidate,
+              label: candidate,
+            })),
+          })
+        );
+      }
+
+      if (nickname === undefined) {
+        const nicknameResult = String(
+          await text({ message: "Nickname (optional):", placeholder: model })
+        ).trim();
+        if (nicknameResult) {
+          nickname = nicknameResult;
+        }
+      }
+
+      if (password === undefined) {
+        const passwordResult = String(
+          await passwordPrompt({
+            message: "Room password (leave empty if none):",
+          })
+        ).trim();
+        if (passwordResult) {
+          password = passwordResult;
+        }
+      }
+    }
+
+    if (!(room && model)) {
+      this.context.stderr.write(
+        "Error: --room and --model are required.\nHint: pass the flags or use --interactive.\n"
+      );
+      return 2;
+    }
+
+    if (!participantId) {
+      this.context.stderr.write(
+        "Error: --participant-id is required.\nHint: provide a stable id for retry-safe registration.\n"
+      );
+      return 2;
+    }
+
+    let authHeaders: ParticipantAuthHeaders;
+    try {
+      authHeaders = resolveAuthHeaders(
+        this.headers,
+        this.headerEnv,
+        envConfig?.headers
+      );
+    } catch (error) {
+      this.context.stderr.write(
+        `Error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      return 2;
+    }
+
+    let runtimeConfig;
+    try {
+      runtimeConfig = await loadRuntimeConfigFromInput(this.configPath);
+    } catch (error) {
+      this.context.stderr.write(
+        `Error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      return 2;
+    }
+
+    const probe = await probeEndpoint(endpoint, { authHeaders });
+    if (!probe.models.includes(model)) {
+      this.context.stderr.write(
+        `Error: Model '${model}' not found on ${endpoint}.\nHint: available models: ${probe.models.join(", ")}\n`
+      );
+      return 3;
+    }
+
+    const publishedEndpoint = resolvePublishedEndpoint(
+      hubUrl,
+      endpoint,
+      this.networkEndpoint ?? envConfig?.networkEndpoint
+    );
+    const specs =
+      this.noSpecs || envConfig?.noSpecs ? undefined : await detectSpecs();
+    const payload = {
+      nickname: nickname ?? `${model}@${participantId.slice(0, 6)}`,
+      model,
+      endpoint: publishedEndpoint,
+      password,
+      specs,
+      config: runtimeConfig,
+      capabilities: probe.capabilities,
+      authHeaders: Object.keys(authHeaders).length > 0 ? authHeaders : undefined,
+    };
+
+    if (this.dryRun) {
+      const preview = {
+        hubUrl,
+        room,
+        participantId,
+        endpoint,
+        publishedEndpoint,
+        payload: {
+          ...payload,
+          authHeaders: payload.authHeaders
+            ? Object.fromEntries(
+                Object.keys(payload.authHeaders).map((key) => [key, "[redacted]"])
+              )
+            : undefined,
+          password: password ? "[redacted]" : undefined,
+        },
+      };
+      if (format === "text") {
+        this.context.stdout.write(
+          `Prepared participant ${participantId} for room ${room}.\n${JSON.stringify(preview, null, 2)}\n`
+        );
+      } else {
+        writeStructured(this.context.stdout, format, preview);
+      }
+      return 0;
+    }
+
+    if (format !== "text") {
+      writeStructured(this.context.stdout, "ndjson", {
+        type: "prepared",
+        timestamp: Date.now(),
+        data: {
+          room,
+          participantId,
+          endpoint,
+          publishedEndpoint,
+        },
+      });
+    }
+
+    const registration = await requestManagement<{
+      participant: {
+        id: string;
+        nickname: string;
+        model: string;
+        endpoint: string;
+      };
+      roomId: string;
+    }>(hubUrl, `/v1/rooms/${room}/participants/${participantId}`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+
+    if (!registration.ok) {
+      this.context.stderr.write(renderFailure(registration.value));
+      return exitCodeForFailure(registration.value);
+    }
+
+    if (format === "text") {
+      this.context.stdout.write(
+        `Registered ${registration.value.data.participant.nickname} in room ${room}.\n`
+      );
+      this.context.stdout.write("Press Ctrl+C to leave.\n");
+    } else {
+      writeStructured(this.context.stdout, "ndjson", {
+        type: "registered",
+        timestamp: Date.now(),
+        data: registration.value.data,
+      });
+    }
+
+    return await new Promise<number>((resolve) => {
+      let closed = false;
+      const heartbeatInterval = setInterval(async () => {
+        const heartbeat = await requestManagement(
+          hubUrl,
+          `/v1/rooms/${room}/participants/${participantId}/heartbeat`,
+          { method: "POST" }
+        );
+
+        if (!heartbeat.ok) {
+          clearInterval(heartbeatInterval);
+          if (format === "text") {
+            this.context.stderr.write(renderFailure(heartbeat.value));
+          } else {
+            writeStructured(this.context.stdout, "ndjson", {
+              type: "heartbeat_failed",
+              timestamp: Date.now(),
+              data: heartbeat.value,
+            });
+          }
+          resolve(exitCodeForFailure(heartbeat.value));
+          return;
+        }
+
+        if (format !== "text") {
+          writeStructured(this.context.stdout, "ndjson", {
+            type: "heartbeat_ok",
+            timestamp: Date.now(),
+            data: heartbeat.value.data,
+          });
+        }
+      }, HEALTH_CHECK_INTERVAL);
+
+      const shutdown = async (signal: string) => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        clearInterval(heartbeatInterval);
+
+        if (format === "text") {
+          this.context.stdout.write(`Leaving room ${room}...\n`);
+        } else {
+          writeStructured(this.context.stdout, "ndjson", {
+            type: "leaving",
+            timestamp: Date.now(),
+            data: { signal, participantId, room },
+          });
+        }
+
+        const leaveResult = await requestManagement<{ success: true }>(
+          hubUrl,
+          `/v1/rooms/${room}/participants/${participantId}`,
+          { method: "DELETE" }
+        );
+        if (!leaveResult.ok) {
+          this.context.stderr.write(renderFailure(leaveResult.value));
+          resolve(exitCodeForFailure(leaveResult.value));
+          return;
+        }
+
+        if (format === "text") {
+          this.context.stdout.write("Left room successfully.\n");
+        } else {
+          writeStructured(this.context.stdout, "ndjson", {
+            type: "left",
+            timestamp: Date.now(),
+            data: { participantId, room },
+          });
+        }
+
+        resolve(0);
+      };
+
+      process.once("SIGINT", () => void shutdown("SIGINT"));
+      process.once("SIGTERM", () => void shutdown("SIGTERM"));
+    });
+  }
+}

--- a/packages/cli/src/commands/participant-join.ts
+++ b/packages/cli/src/commands/participant-join.ts
@@ -63,20 +63,39 @@ function resolveAuthHeaders(
   return authHeaders;
 }
 
-function resolvePublishedEndpoint(
+export function resolvePublishedEndpoint(
   hubUrl: string,
   endpoint: string,
   explicitNetworkEndpoint?: string
 ): string {
+  const invalidEndpointHint =
+    "Hint: pass --endpoint with a full URL such as http://localhost:11434.";
+  const invalidNetworkEndpointHint =
+    "Hint: pass --network-endpoint with a full URL such as http://192.168.1.25:11434.";
+
   if (explicitNetworkEndpoint) {
-    return new URL(explicitNetworkEndpoint).toString();
+    try {
+      return new URL(explicitNetworkEndpoint).toString();
+    } catch {
+      throw new Error(
+        `Invalid --network-endpoint URL: ${explicitNetworkEndpoint}.\n${invalidNetworkEndpointHint}`
+      );
+    }
   }
 
   if (!isRemoteHubUrl(hubUrl)) {
     return endpoint;
   }
 
-  const hostname = new URL(endpoint).hostname;
+  let hostname: string;
+  try {
+    hostname = new URL(endpoint).hostname;
+  } catch {
+    throw new Error(
+      `Invalid endpoint URL: ${endpoint}.\n${invalidEndpointHint}`
+    );
+  }
+
   if (!isLoopbackLikeHost(hostname)) {
     return endpoint;
   }
@@ -91,7 +110,10 @@ function resolvePublishedEndpoint(
 
   if (publishedEndpoints.length === 0) {
     throw new Error(
-      "Remote hub detected, but no LAN endpoint could be inferred. Pass --network-endpoint."
+      [
+        "Remote hub detected, but no LAN endpoint could be inferred.",
+        "Hint: pass --network-endpoint with the URL that the hub can reach.",
+      ].join("\n")
     );
   }
 
@@ -294,6 +316,15 @@ export class ParticipantJoinCommand extends AgentCommand {
       return 2;
     }
 
+    try {
+      new URL(endpoint);
+    } catch {
+      this.context.stderr.write(
+        `Error: Invalid endpoint URL: ${endpoint}.\nHint: pass --endpoint with a full URL such as http://localhost:11434.\n`
+      );
+      return 2;
+    }
+
     const probe = await probeEndpoint(endpoint, { authHeaders });
     if (!probe.models.includes(model)) {
       this.context.stderr.write(
@@ -302,11 +333,19 @@ export class ParticipantJoinCommand extends AgentCommand {
       return 3;
     }
 
-    const publishedEndpoint = resolvePublishedEndpoint(
-      hubUrl,
-      endpoint,
-      this.networkEndpoint ?? envConfig?.networkEndpoint
-    );
+    let publishedEndpoint: string;
+    try {
+      publishedEndpoint = resolvePublishedEndpoint(
+        hubUrl,
+        endpoint,
+        this.networkEndpoint ?? envConfig?.networkEndpoint
+      );
+    } catch (error) {
+      this.context.stderr.write(
+        `Error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      return 2;
+    }
     const specs =
       this.noSpecs || envConfig?.noSpecs ? undefined : await detectSpecs();
     const payload = {
@@ -397,6 +436,19 @@ export class ParticipantJoinCommand extends AgentCommand {
 
     return await new Promise<number>((resolve) => {
       let closed = false;
+      let heartbeatInterval: ReturnType<typeof setInterval>;
+      const onSigint = () => {
+        shutdown("SIGINT").catch(() => undefined);
+      };
+      const onSigterm = () => {
+        shutdown("SIGTERM").catch(() => undefined);
+      };
+      const cleanup = () => {
+        clearInterval(heartbeatInterval);
+        process.off("SIGINT", onSigint);
+        process.off("SIGTERM", onSigterm);
+      };
+
       const handleHeartbeatFailure = (
         message: string,
         failure: ApiFailure = {
@@ -408,7 +460,11 @@ export class ParticipantJoinCommand extends AgentCommand {
           },
         }
       ) => {
-        clearInterval(heartbeatInterval);
+        if (closed) {
+          return;
+        }
+        closed = true;
+        cleanup();
         if (format === "text") {
           this.context.stderr.write(renderFailure(failure));
         } else {
@@ -421,7 +477,7 @@ export class ParticipantJoinCommand extends AgentCommand {
         resolve(exitCodeForFailure(failure));
       };
 
-      const heartbeatInterval = setInterval(async () => {
+      heartbeatInterval = setInterval(async () => {
         try {
           const heartbeat = await requestManagement(
             hubUrl,
@@ -430,7 +486,10 @@ export class ParticipantJoinCommand extends AgentCommand {
           );
 
           if (!heartbeat.ok) {
-            handleHeartbeatFailure(heartbeat.value.error.message, heartbeat.value);
+            handleHeartbeatFailure(
+              heartbeat.value.error.message,
+              heartbeat.value
+            );
             return;
           }
 
@@ -453,7 +512,7 @@ export class ParticipantJoinCommand extends AgentCommand {
           return;
         }
         closed = true;
-        clearInterval(heartbeatInterval);
+        cleanup();
 
         if (format === "text") {
           this.context.stdout.write(`Leaving room ${room}...\n`);
@@ -489,12 +548,8 @@ export class ParticipantJoinCommand extends AgentCommand {
         resolve(0);
       };
 
-      process.once("SIGINT", () => {
-        shutdown("SIGINT").catch(() => undefined);
-      });
-      process.once("SIGTERM", () => {
-        shutdown("SIGTERM").catch(() => undefined);
-      });
+      process.once("SIGINT", onSigint);
+      process.once("SIGTERM", onSigterm);
     });
   }
 }

--- a/packages/cli/src/commands/participant-join.ts
+++ b/packages/cli/src/commands/participant-join.ts
@@ -26,16 +26,22 @@ import { writeStructured } from "../utils/output.ts";
 import { handleCancel } from "../utils/prompt.ts";
 import { detectSpecs } from "../utils/specs.ts";
 
-function parseHeaderAssignment(input: string): { name: string; value: string } {
+export function parseHeaderAssignment(input: string): {
+  name: string;
+  value: string;
+} {
   const index = input.indexOf("=");
   if (index <= 0 || index === input.length - 1) {
     throw new Error(`Invalid header assignment '${input}'. Use Header=Value.`);
   }
 
-  return {
-    name: input.slice(0, index).trim(),
-    value: input.slice(index + 1).trim(),
-  };
+  const name = input.slice(0, index).trim();
+  const value = input.slice(index + 1).trim();
+  if (!(name && value)) {
+    throw new Error(`Invalid header assignment '${input}'. Use Header=Value.`);
+  }
+
+  return { name, value };
 }
 
 function resolveAuthHeaders(

--- a/packages/cli/src/commands/participant-join.ts
+++ b/packages/cli/src/commands/participant-join.ts
@@ -9,6 +9,7 @@ import { nanoid } from "nanoid";
 import { AgentCommand } from "../utils/agent-command.ts";
 import { loadRuntimeConfigFromInput } from "../utils/cli-config.ts";
 import {
+  type ApiFailure,
   exitCodeForFailure,
   renderFailure,
   requestManagement,
@@ -396,34 +397,54 @@ export class ParticipantJoinCommand extends AgentCommand {
 
     return await new Promise<number>((resolve) => {
       let closed = false;
-      const heartbeatInterval = setInterval(async () => {
-        const heartbeat = await requestManagement(
-          hubUrl,
-          `/v1/rooms/${room}/participants/${participantId}/heartbeat`,
-          { method: "POST" }
-        );
+      const handleHeartbeatFailure = (
+        message: string,
+        failure: ApiFailure = {
+          status: 503,
+          error: {
+            code: "INTERNAL_ERROR" as const,
+            message,
+            hint: "Check hub URL and connectivity.",
+          },
+        }
+      ) => {
+        clearInterval(heartbeatInterval);
+        if (format === "text") {
+          this.context.stderr.write(renderFailure(failure));
+        } else {
+          writeStructured(this.context.stdout, format, {
+            type: "heartbeat_failed",
+            timestamp: Date.now(),
+            data: failure,
+          });
+        }
+        resolve(exitCodeForFailure(failure));
+      };
 
-        if (!heartbeat.ok) {
-          clearInterval(heartbeatInterval);
-          if (format === "text") {
-            this.context.stderr.write(renderFailure(heartbeat.value));
-          } else {
+      const heartbeatInterval = setInterval(async () => {
+        try {
+          const heartbeat = await requestManagement(
+            hubUrl,
+            `/v1/rooms/${room}/participants/${participantId}/heartbeat`,
+            { method: "POST" }
+          );
+
+          if (!heartbeat.ok) {
+            handleHeartbeatFailure(heartbeat.value.error.message, heartbeat.value);
+            return;
+          }
+
+          if (format !== "text") {
             writeStructured(this.context.stdout, format, {
-              type: "heartbeat_failed",
+              type: "heartbeat_ok",
               timestamp: Date.now(),
-              data: heartbeat.value,
+              data: heartbeat.value.data,
             });
           }
-          resolve(exitCodeForFailure(heartbeat.value));
-          return;
-        }
-
-        if (format !== "text") {
-          writeStructured(this.context.stdout, format, {
-            type: "heartbeat_ok",
-            timestamp: Date.now(),
-            data: heartbeat.value.data,
-          });
+        } catch (error) {
+          handleHeartbeatFailure(
+            error instanceof Error ? error.message : String(error)
+          );
         }
       }, HEALTH_CHECK_INTERVAL);
 

--- a/packages/cli/src/commands/participant-join.ts
+++ b/packages/cli/src/commands/participant-join.ts
@@ -23,6 +23,7 @@ import {
 } from "../utils/network-endpoint.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
+import { handleCancel } from "../utils/prompt.ts";
 import { detectSpecs } from "../utils/specs.ts";
 
 function parseHeaderAssignment(input: string): { name: string; value: string } {
@@ -223,13 +224,18 @@ export class ParticipantJoinCommand extends AgentCommand {
 
     if (this.allowInteractive(true)) {
       if (!room) {
-        room = String(await text({ message: "Room code:" })).trim();
+        const roomResult = await text({ message: "Room code:" });
+        handleCancel(roomResult);
+        room = String(roomResult).trim();
       }
 
       if (!participantId) {
-        participantId = String(
-          await text({ message: "Participant ID:", placeholder: nanoid(8) })
-        ).trim();
+        const participantIdResult = await text({
+          message: "Participant ID:",
+          placeholder: nanoid(8),
+        });
+        handleCancel(participantIdResult);
+        participantId = String(participantIdResult).trim();
       }
 
       if (!model) {
@@ -246,32 +252,35 @@ export class ParticipantJoinCommand extends AgentCommand {
           );
           return 3;
         }
-        model = String(
-          await select({
-            message: "Model:",
-            options: probe.models.map((candidate) => ({
-              value: candidate,
-              label: candidate,
-            })),
-          })
-        );
+        const modelResult = await select({
+          message: "Model:",
+          options: probe.models.map((candidate) => ({
+            value: candidate,
+            label: candidate,
+          })),
+        });
+        handleCancel(modelResult);
+        model = String(modelResult);
       }
 
       if (nickname === undefined) {
-        const nicknameResult = String(
-          await text({ message: "Nickname (optional):", placeholder: model })
-        ).trim();
+        const nicknamePromptResult = await text({
+          message: "Nickname (optional):",
+          placeholder: model,
+        });
+        handleCancel(nicknamePromptResult);
+        const nicknameResult = String(nicknamePromptResult).trim();
         if (nicknameResult) {
           nickname = nicknameResult;
         }
       }
 
       if (password === undefined) {
-        const passwordResult = String(
-          await passwordPrompt({
-            message: "Room password (leave empty if none):",
-          })
-        ).trim();
+        const passwordPromptResult = await passwordPrompt({
+          message: "Room password (leave empty if none):",
+        });
+        handleCancel(passwordPromptResult);
+        const passwordResult = String(passwordPromptResult).trim();
         if (passwordResult) {
           password = passwordResult;
         }

--- a/packages/cli/src/commands/participant-join.ts
+++ b/packages/cli/src/commands/participant-join.ts
@@ -1,11 +1,18 @@
-import {
-  password as passwordPrompt,
-  select,
-  text,
-} from "@clack/prompts";
+import { password as passwordPrompt, select, text } from "@clack/prompts";
 import { probeEndpoint } from "@gambi/core/endpoint";
-import { HEALTH_CHECK_INTERVAL, type ParticipantAuthHeaders } from "@gambi/core/types";
+import {
+  HEALTH_CHECK_INTERVAL,
+  type ParticipantAuthHeaders,
+  type RuntimeConfig,
+} from "@gambi/core/types";
 import { nanoid } from "nanoid";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadRuntimeConfigFromInput } from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
 import {
   isLoopbackLikeHost,
   isRemoteHubUrl,
@@ -13,17 +20,6 @@ import {
   rankNetworkCandidatesForHub,
   replaceEndpointHost,
 } from "../utils/network-endpoint.ts";
-import { AgentCommand } from "../utils/agent-command.ts";
-import {
-  loadCliConfig,
-  loadRuntimeConfigFromInput,
-  resolveEnvConfig,
-} from "../utils/cli-config.ts";
-import {
-  exitCodeForFailure,
-  renderFailure,
-  requestManagement,
-} from "../utils/management-api.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
 import { detectSpecs } from "../utils/specs.ts";
@@ -31,9 +27,7 @@ import { detectSpecs } from "../utils/specs.ts";
 function parseHeaderAssignment(input: string): { name: string; value: string } {
   const index = input.indexOf("=");
   if (index <= 0 || index === input.length - 1) {
-    throw new Error(
-      `Invalid header assignment '${input}'. Use Header=Value.`
-    );
+    throw new Error(`Invalid header assignment '${input}'. Use Header=Value.`);
   }
 
   return {
@@ -117,7 +111,7 @@ export class ParticipantJoinCommand extends AgentCommand {
       ],
       [
         "Preview the registration",
-        "gambi participant join --room ABC123 --participant-id worker-1 --model llama3 --dry-run --format json",
+        "gambi participant join --room ABC123 --participant-id worker-1 --model llama3 --dry-run --format ndjson",
       ],
       [
         "Register against a remote hub",
@@ -188,10 +182,14 @@ export class ParticipantJoinCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const cliConfig = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(cliConfig, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
-    const endpoint = this.endpoint ?? envConfig?.endpoint ?? "http://localhost:11434";
+    const endpoint =
+      this.endpoint ?? envConfig?.endpoint ?? "http://localhost:11434";
     const format = this.resolveFormat(true);
 
     let room = this.room;
@@ -285,7 +283,7 @@ export class ParticipantJoinCommand extends AgentCommand {
       return 2;
     }
 
-    let runtimeConfig;
+    let runtimeConfig: RuntimeConfig | undefined;
     try {
       runtimeConfig = await loadRuntimeConfigFromInput(this.configPath);
     } catch (error) {
@@ -318,7 +316,8 @@ export class ParticipantJoinCommand extends AgentCommand {
       specs,
       config: runtimeConfig,
       capabilities: probe.capabilities,
-      authHeaders: Object.keys(authHeaders).length > 0 ? authHeaders : undefined,
+      authHeaders:
+        Object.keys(authHeaders).length > 0 ? authHeaders : undefined,
     };
 
     if (this.dryRun) {
@@ -332,7 +331,10 @@ export class ParticipantJoinCommand extends AgentCommand {
           ...payload,
           authHeaders: payload.authHeaders
             ? Object.fromEntries(
-                Object.keys(payload.authHeaders).map((key) => [key, "[redacted]"])
+                Object.keys(payload.authHeaders).map((key) => [
+                  key,
+                  "[redacted]",
+                ])
               )
             : undefined,
           password: password ? "[redacted]" : undefined,
@@ -349,7 +351,7 @@ export class ParticipantJoinCommand extends AgentCommand {
     }
 
     if (format !== "text") {
-      writeStructured(this.context.stdout, "ndjson", {
+      writeStructured(this.context.stdout, format, {
         type: "prepared",
         timestamp: Date.now(),
         data: {
@@ -385,7 +387,7 @@ export class ParticipantJoinCommand extends AgentCommand {
       );
       this.context.stdout.write("Press Ctrl+C to leave.\n");
     } else {
-      writeStructured(this.context.stdout, "ndjson", {
+      writeStructured(this.context.stdout, format, {
         type: "registered",
         timestamp: Date.now(),
         data: registration.value.data,
@@ -406,7 +408,7 @@ export class ParticipantJoinCommand extends AgentCommand {
           if (format === "text") {
             this.context.stderr.write(renderFailure(heartbeat.value));
           } else {
-            writeStructured(this.context.stdout, "ndjson", {
+            writeStructured(this.context.stdout, format, {
               type: "heartbeat_failed",
               timestamp: Date.now(),
               data: heartbeat.value,
@@ -417,7 +419,7 @@ export class ParticipantJoinCommand extends AgentCommand {
         }
 
         if (format !== "text") {
-          writeStructured(this.context.stdout, "ndjson", {
+          writeStructured(this.context.stdout, format, {
             type: "heartbeat_ok",
             timestamp: Date.now(),
             data: heartbeat.value.data,
@@ -435,7 +437,7 @@ export class ParticipantJoinCommand extends AgentCommand {
         if (format === "text") {
           this.context.stdout.write(`Leaving room ${room}...\n`);
         } else {
-          writeStructured(this.context.stdout, "ndjson", {
+          writeStructured(this.context.stdout, format, {
             type: "leaving",
             timestamp: Date.now(),
             data: { signal, participantId, room },
@@ -456,7 +458,7 @@ export class ParticipantJoinCommand extends AgentCommand {
         if (format === "text") {
           this.context.stdout.write("Left room successfully.\n");
         } else {
-          writeStructured(this.context.stdout, "ndjson", {
+          writeStructured(this.context.stdout, format, {
             type: "left",
             timestamp: Date.now(),
             data: { participantId, room },
@@ -466,8 +468,12 @@ export class ParticipantJoinCommand extends AgentCommand {
         resolve(0);
       };
 
-      process.once("SIGINT", () => void shutdown("SIGINT"));
-      process.once("SIGTERM", () => void shutdown("SIGTERM"));
+      process.once("SIGINT", () => {
+        shutdown("SIGINT").catch(() => undefined);
+      });
+      process.once("SIGTERM", () => {
+        shutdown("SIGTERM").catch(() => undefined);
+      });
     });
   }
 }

--- a/packages/cli/src/commands/participant-leave.ts
+++ b/packages/cli/src/commands/participant-leave.ts
@@ -1,0 +1,66 @@
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+export class ParticipantLeaveCommand extends AgentCommand {
+  static override paths = [["participant", "leave"]];
+
+  static override usage = Command.Usage({
+    description: "Remove a participant from a room",
+    details:
+      "Calls the management API to delete a participant registration from a room.",
+    examples: [
+      [
+        "Remove a participant",
+        "gambi participant leave --room ABC123 --participant-id worker-1",
+      ],
+    ],
+  });
+
+  room = Option.String("--room,-r", {
+    description: "Room code",
+  });
+
+  participantId = Option.String("--participant-id", {
+    description: "Participant identifier",
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const format = this.resolveFormat(false);
+
+    const response = await requestManagement<{ success: true }>(
+      hubUrl,
+      `/v1/rooms/${this.room}/participants/${this.participantId}`,
+      { method: "DELETE" }
+    );
+
+    if (!response.ok) {
+      this.context.stderr.write(renderFailure(response.value));
+      return exitCodeForFailure(response.value);
+    }
+
+    if (format !== "text") {
+      writeStructured(this.context.stdout, format, response.value);
+      return 0;
+    }
+
+    this.context.stdout.write(
+      `Removed participant ${this.participantId} from room ${this.room}.\n`
+    );
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/participant-leave.ts
+++ b/packages/cli/src/commands/participant-leave.ts
@@ -1,5 +1,4 @@
 import { AgentCommand } from "../utils/agent-command.ts";
-import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
 import {
   exitCodeForFailure,
   renderFailure,
@@ -37,8 +36,11 @@ export class ParticipantLeaveCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
     const format = this.resolveFormat(false);
 

--- a/packages/cli/src/commands/room-create.ts
+++ b/packages/cli/src/commands/room-create.ts
@@ -1,0 +1,142 @@
+import { password as passwordPrompt, text } from "@clack/prompts";
+import type { RoomSummary, RuntimeConfig } from "@gambi/core/types";
+import { AgentCommand } from "../utils/agent-command.ts";
+import {
+  loadCliConfig,
+  loadRuntimeConfigFromInput,
+  resolveEnvConfig,
+} from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+export class RoomCreateCommand extends AgentCommand {
+  static override paths = [["room", "create"]];
+
+  static override usage = Command.Usage({
+    description: "Create a room through the management API",
+    details:
+      "Creates a new room and optionally attaches runtime defaults from JSON. Use --config - to read JSON from stdin.",
+    examples: [
+      ["Create a room", "gambi room create --name Demo"],
+      ["Create with defaults", "gambi room create --name Demo --config ./room.json"],
+      ["Preview request", "gambi room create --name Demo --dry-run --format json"],
+    ],
+  });
+
+  name = Option.String("--name,-n", {
+    description: "Room name",
+    required: false,
+  });
+
+  password = Option.String("--password,-p", {
+    description: "Optional room password",
+    required: false,
+  });
+
+  configPath = Option.String("--config", {
+    description: "Runtime config JSON file or '-' for stdin",
+    required: false,
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  dryRun = Option.Boolean("--dry-run", false, {
+    description: "Validate and print the request without creating the room",
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const format = this.resolveFormat(false);
+    let name = this.name;
+    let password = this.password;
+
+    if (!name && this.allowInteractive(true)) {
+      const nameResult = await text({ message: "Room name:" });
+      name = String(nameResult).trim();
+
+      if (password === undefined) {
+        const passwordResult = await passwordPrompt({
+          message: "Room password (leave empty for none):",
+        });
+        const candidatePassword = String(passwordResult).trim();
+        if (candidatePassword) {
+          password = candidatePassword;
+        }
+      }
+    }
+
+    if (!name) {
+      this.context.stderr.write(
+        "Error: Room name is required.\nHint: pass --name or use --interactive.\n"
+      );
+      return 2;
+    }
+
+    let runtimeConfig: RuntimeConfig | undefined;
+    try {
+      runtimeConfig = await loadRuntimeConfigFromInput(this.configPath);
+    } catch (error) {
+      this.context.stderr.write(
+        `Error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      return 2;
+    }
+
+    const payload = {
+      name,
+      password,
+      defaults: runtimeConfig,
+    };
+
+    if (this.dryRun) {
+      const preview = {
+        hubUrl,
+        payload: {
+          ...payload,
+          password: password ? "[redacted]" : undefined,
+        },
+      };
+      if (format === "text") {
+        this.context.stdout.write(
+          `Would create room '${name}' on ${hubUrl}.\n${JSON.stringify(preview.payload, null, 2)}\n`
+        );
+      } else {
+        writeStructured(this.context.stdout, format, preview);
+      }
+      return 0;
+    }
+
+    const response = await requestManagement<{ room: RoomSummary; hostId: string }>(
+      hubUrl,
+      "/v1/rooms",
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }
+    );
+    if (!response.ok) {
+      this.context.stderr.write(renderFailure(response.value));
+      return exitCodeForFailure(response.value);
+    }
+
+    if (format !== "text") {
+      writeStructured(this.context.stdout, format, response.value);
+      return 0;
+    }
+
+    const { room, hostId } = response.value.data;
+    this.context.stdout.write(`Created room ${room.code} (${room.name}).\n`);
+    this.context.stdout.write(`host_id: ${hostId}\n`);
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/room-create.ts
+++ b/packages/cli/src/commands/room-create.ts
@@ -1,11 +1,7 @@
 import { password as passwordPrompt, text } from "@clack/prompts";
 import type { RoomSummary, RuntimeConfig } from "@gambi/core/types";
 import { AgentCommand } from "../utils/agent-command.ts";
-import {
-  loadCliConfig,
-  loadRuntimeConfigFromInput,
-  resolveEnvConfig,
-} from "../utils/cli-config.ts";
+import { loadRuntimeConfigFromInput } from "../utils/cli-config.ts";
 import {
   exitCodeForFailure,
   renderFailure,
@@ -13,6 +9,30 @@ import {
 } from "../utils/management-api.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
+
+async function promptForRoomSettings(params: {
+  name?: string;
+  password?: string;
+}): Promise<{ name?: string; password?: string }> {
+  let { name, password } = params;
+
+  if (!name) {
+    const nameResult = await text({ message: "Room name:" });
+    name = String(nameResult).trim();
+  }
+
+  if (password === undefined) {
+    const passwordResult = await passwordPrompt({
+      message: "Room password (leave empty for none):",
+    });
+    const candidatePassword = String(passwordResult).trim();
+    if (candidatePassword) {
+      password = candidatePassword;
+    }
+  }
+
+  return { name, password };
+}
 
 export class RoomCreateCommand extends AgentCommand {
   static override paths = [["room", "create"]];
@@ -23,8 +43,14 @@ export class RoomCreateCommand extends AgentCommand {
       "Creates a new room and optionally attaches runtime defaults from JSON. Use --config - to read JSON from stdin.",
     examples: [
       ["Create a room", "gambi room create --name Demo"],
-      ["Create with defaults", "gambi room create --name Demo --config ./room.json"],
-      ["Preview request", "gambi room create --name Demo --dry-run --format json"],
+      [
+        "Create with defaults",
+        "gambi room create --name Demo --config ./room.json",
+      ],
+      [
+        "Preview request",
+        "gambi room create --name Demo --dry-run --format json",
+      ],
     ],
   });
 
@@ -53,26 +79,18 @@ export class RoomCreateCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
     const format = this.resolveFormat(false);
     let name = this.name;
     let password = this.password;
 
     if (!name && this.allowInteractive(true)) {
-      const nameResult = await text({ message: "Room name:" });
-      name = String(nameResult).trim();
-
-      if (password === undefined) {
-        const passwordResult = await passwordPrompt({
-          message: "Room password (leave empty for none):",
-        });
-        const candidatePassword = String(passwordResult).trim();
-        if (candidatePassword) {
-          password = candidatePassword;
-        }
-      }
+      ({ name, password } = await promptForRoomSettings({ name, password }));
     }
 
     if (!name) {
@@ -116,14 +134,13 @@ export class RoomCreateCommand extends AgentCommand {
       return 0;
     }
 
-    const response = await requestManagement<{ room: RoomSummary; hostId: string }>(
-      hubUrl,
-      "/v1/rooms",
-      {
-        method: "POST",
-        body: JSON.stringify(payload),
-      }
-    );
+    const response = await requestManagement<{
+      room: RoomSummary;
+      hostId: string;
+    }>(hubUrl, "/v1/rooms", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
     if (!response.ok) {
       this.context.stderr.write(renderFailure(response.value));
       return exitCodeForFailure(response.value);

--- a/packages/cli/src/commands/room-create.ts
+++ b/packages/cli/src/commands/room-create.ts
@@ -9,6 +9,7 @@ import {
 } from "../utils/management-api.ts";
 import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
+import { handleCancel } from "../utils/prompt.ts";
 
 async function promptForRoomSettings(params: {
   name?: string;
@@ -18,6 +19,7 @@ async function promptForRoomSettings(params: {
 
   if (!name) {
     const nameResult = await text({ message: "Room name:" });
+    handleCancel(nameResult);
     name = String(nameResult).trim();
   }
 
@@ -25,6 +27,7 @@ async function promptForRoomSettings(params: {
     const passwordResult = await passwordPrompt({
       message: "Room password (leave empty for none):",
     });
+    handleCancel(passwordResult);
     const candidatePassword = String(passwordResult).trim();
     if (candidatePassword) {
       password = candidatePassword;

--- a/packages/cli/src/commands/room-get.ts
+++ b/packages/cli/src/commands/room-get.ts
@@ -1,0 +1,70 @@
+import type { RoomSummary } from "@gambi/core/types";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+export class RoomGetCommand extends AgentCommand {
+  static override paths = [["room", "get"]];
+
+  static override usage = Command.Usage({
+    description: "Fetch one room summary by code",
+    details:
+      "Returns a single room summary from the management API, including participant count and password protection status.",
+    examples: [
+      ["Get one room", "gambi room get --code ABC123"],
+      ["Get as JSON", "gambi room get --code ABC123 --format json"],
+    ],
+  });
+
+  code = Option.String("--code,-c", {
+    description: "Room code",
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const format = this.resolveFormat(false);
+
+    const response = await requestManagement<RoomSummary>(
+      hubUrl,
+      `/v1/rooms/${this.code}`
+    );
+    if (!response.ok) {
+      this.context.stderr.write(renderFailure(response.value));
+      return exitCodeForFailure(response.value);
+    }
+
+    if (format !== "text") {
+      writeStructured(this.context.stdout, format, response.value);
+      return 0;
+    }
+
+    const room = response.value.data;
+    this.context.stdout.write(`${room.code}  ${room.name}\n`);
+    this.context.stdout.write(`participants: ${room.participantCount}\n`);
+    this.context.stdout.write(
+      `protected: ${room.passwordProtected ? "yes" : "no"}\n`
+    );
+    this.context.stdout.write(
+      `created_at: ${new Date(room.createdAt).toISOString()}\n`
+    );
+    if (room.defaults) {
+      this.context.stdout.write(
+        `defaults: ${JSON.stringify(room.defaults, null, 2)}\n`
+      );
+    }
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/room-get.ts
+++ b/packages/cli/src/commands/room-get.ts
@@ -1,6 +1,5 @@
 import type { RoomSummary } from "@gambi/core/types";
 import { AgentCommand } from "../utils/agent-command.ts";
-import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
 import {
   exitCodeForFailure,
   renderFailure,
@@ -32,8 +31,11 @@ export class RoomGetCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
     const format = this.resolveFormat(false);
 

--- a/packages/cli/src/commands/room-list.test.ts
+++ b/packages/cli/src/commands/room-list.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { parseRoomSort } from "./room-list.ts";
+
+describe("room list sort parsing", () => {
+  test("accepts supported sort values", () => {
+    expect(parseRoomSort("participant-count")).toBe("participant-count");
+    expect(parseRoomSort("created-at")).toBe("created-at");
+    expect(parseRoomSort("name")).toBe("name");
+  });
+
+  test("rejects unsupported sort values", () => {
+    expect(parseRoomSort("random")).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/room-list.ts
+++ b/packages/cli/src/commands/room-list.ts
@@ -1,6 +1,5 @@
 import type { RoomSummary } from "@gambi/core/types";
 import { AgentCommand } from "../utils/agent-command.ts";
-import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
 import {
   exitCodeForFailure,
   renderFailure,
@@ -41,7 +40,10 @@ export class RoomListCommand extends AgentCommand {
     examples: [
       ["List rooms", "gambi room list"],
       ["List as JSON", "gambi room list --format json"],
-      ["List from another hub", "gambi room list --hub http://192.168.1.10:3000"],
+      [
+        "List from another hub",
+        "gambi room list --hub http://192.168.1.10:3000",
+      ],
     ],
   });
 
@@ -59,13 +61,19 @@ export class RoomListCommand extends AgentCommand {
   });
 
   async execute(): Promise<number> {
-    const config = await loadCliConfig(this.resolveConfigPath());
-    const envConfig = resolveEnvConfig(config, this.env);
+    const envConfigResult = await this.loadEnvConfig();
+    if (!envConfigResult.ok) {
+      return envConfigResult.exitCode;
+    }
+    const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
     const sortBy = (this.sort ?? "participant-count") as RoomSort;
     const format = this.resolveFormat(false);
 
-    const response = await requestManagement<RoomSummary[]>(hubUrl, "/v1/rooms");
+    const response = await requestManagement<RoomSummary[]>(
+      hubUrl,
+      "/v1/rooms"
+    );
     if (!response.ok) {
       this.context.stderr.write(renderFailure(response.value));
       return exitCodeForFailure(response.value);

--- a/packages/cli/src/commands/room-list.ts
+++ b/packages/cli/src/commands/room-list.ts
@@ -1,0 +1,101 @@
+import type { RoomSummary } from "@gambi/core/types";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { loadCliConfig, resolveEnvConfig } from "../utils/cli-config.ts";
+import {
+  exitCodeForFailure,
+  renderFailure,
+  requestManagement,
+} from "../utils/management-api.ts";
+import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+
+type RoomSort = "participant-count" | "created-at" | "name";
+
+function sortRooms(rooms: RoomSummary[], sortBy: RoomSort, reverse: boolean) {
+  const sorted = [...rooms].sort((left, right) => {
+    if (sortBy === "name") {
+      return left.name.localeCompare(right.name);
+    }
+
+    if (sortBy === "created-at") {
+      return right.createdAt - left.createdAt;
+    }
+
+    if (right.participantCount !== left.participantCount) {
+      return right.participantCount - left.participantCount;
+    }
+
+    return right.createdAt - left.createdAt;
+  });
+
+  return reverse ? sorted.reverse() : sorted;
+}
+
+export class RoomListCommand extends AgentCommand {
+  static override paths = [["room", "list"]];
+
+  static override usage = Command.Usage({
+    description: "List rooms from the management API",
+    details:
+      "Returns structured room summaries from the hub management plane. Use --format json for scripts.",
+    examples: [
+      ["List rooms", "gambi room list"],
+      ["List as JSON", "gambi room list --format json"],
+      ["List from another hub", "gambi room list --hub http://192.168.1.10:3000"],
+    ],
+  });
+
+  hub = Option.String("--hub,-H", {
+    description: "Hub URL",
+    required: false,
+  });
+
+  sort = Option.String("--sort", "participant-count", {
+    description: "Sort by participant-count, created-at, or name",
+  });
+
+  reverse = Option.Boolean("--reverse", false, {
+    description: "Reverse the selected sort order",
+  });
+
+  async execute(): Promise<number> {
+    const config = await loadCliConfig(this.resolveConfigPath());
+    const envConfig = resolveEnvConfig(config, this.env);
+    const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
+    const sortBy = (this.sort ?? "participant-count") as RoomSort;
+    const format = this.resolveFormat(false);
+
+    const response = await requestManagement<RoomSummary[]>(hubUrl, "/v1/rooms");
+    if (!response.ok) {
+      this.context.stderr.write(renderFailure(response.value));
+      return exitCodeForFailure(response.value);
+    }
+
+    const rooms = sortRooms(response.value.data, sortBy, this.reverse);
+    if (format !== "text") {
+      writeStructured(this.context.stdout, format, {
+        data: rooms,
+        meta: response.value.meta,
+      });
+      return 0;
+    }
+
+    if (rooms.length === 0) {
+      this.context.stdout.write("No rooms found.\n");
+      return 0;
+    }
+
+    for (const room of rooms) {
+      this.context.stdout.write(`${room.code}  ${room.name}\n`);
+      this.context.stdout.write(`  participants: ${room.participantCount}\n`);
+      this.context.stdout.write(
+        `  protected: ${room.passwordProtected ? "yes" : "no"}\n`
+      );
+      this.context.stdout.write(
+        `  created_at: ${new Date(room.createdAt).toISOString()}\n\n`
+      );
+    }
+
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/room-list.ts
+++ b/packages/cli/src/commands/room-list.ts
@@ -9,6 +9,13 @@ import { Command, Option } from "../utils/option.ts";
 import { writeStructured } from "../utils/output.ts";
 
 type RoomSort = "participant-count" | "created-at" | "name";
+const ROOM_SORT_VALUES = ["participant-count", "created-at", "name"] as const;
+
+export function parseRoomSort(value: string): RoomSort | null {
+  return ROOM_SORT_VALUES.includes(value as RoomSort)
+    ? (value as RoomSort)
+    : null;
+}
 
 function sortRooms(rooms: RoomSummary[], sortBy: RoomSort, reverse: boolean) {
   const sorted = [...rooms].sort((left, right) => {
@@ -67,7 +74,13 @@ export class RoomListCommand extends AgentCommand {
     }
     const envConfig = envConfigResult.value;
     const hubUrl = this.hub ?? envConfig?.hubUrl ?? "http://localhost:3000";
-    const sortBy = (this.sort ?? "participant-count") as RoomSort;
+    const sortBy = parseRoomSort(this.sort ?? "participant-count");
+    if (!sortBy) {
+      this.context.stderr.write(
+        `Error: Invalid sort '${this.sort}'.\nHint: use participant-count, created-at, or name.\n`
+      );
+      return 2;
+    }
     const format = this.resolveFormat(false);
 
     const response = await requestManagement<RoomSummary[]>(

--- a/packages/cli/src/commands/self-update.test.ts
+++ b/packages/cli/src/commands/self-update.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { runPackageManagerUpdate } from "./self-update.ts";
+
+describe("self update package-manager execution", () => {
+  test("captures child output for structured formats", () => {
+    const result = runPackageManagerUpdate(
+      "npm",
+      ["install", "-g", "gambi@latest"],
+      {
+        captureOutput: true,
+        spawnImpl: (() => ({
+          error: undefined,
+          status: 0,
+          stdout: "updated\n",
+          stderr: "warning\n",
+        })) as unknown as NonNullable<
+          Parameters<typeof runPackageManagerUpdate>[2]
+        >["spawnImpl"],
+      }
+    );
+
+    expect(result).toEqual({
+      code: 0,
+      stdout: "updated\n",
+      stderr: "warning\n",
+    });
+  });
+});

--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -1,13 +1,14 @@
-import { confirm } from "@clack/prompts";
 import { spawnSync } from "node:child_process";
+import { confirm } from "@clack/prompts";
 import { AgentCommand } from "../utils/agent-command.ts";
 import { Command, Option } from "../utils/option.ts";
+import { writeStructured } from "../utils/output.ts";
+import { handleCancel } from "../utils/prompt.ts";
 import {
   executeStandaloneUpdate,
   normalizePackageManager,
   resolveUpdatePlan,
 } from "../utils/update.ts";
-import { writeStructured } from "../utils/output.ts";
 
 function runPackageManagerUpdate(manager: "bun" | "npm", args: string[]) {
   const result = spawnSync(manager, args, {
@@ -79,6 +80,7 @@ export class SelfUpdateCommand extends AgentCommand {
         message: `Run update now?\n${plan.command}`,
         initialValue: true,
       });
+      handleCancel(shouldProceed);
       if (!shouldProceed) {
         this.context.stdout.write("Update cancelled.\n");
         return 0;

--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -10,9 +10,23 @@ import {
   resolveUpdatePlan,
 } from "../utils/update.ts";
 
-function runPackageManagerUpdate(manager: "bun" | "npm", args: string[]) {
-  const result = spawnSync(manager, args, {
-    stdio: "inherit",
+export interface PackageManagerUpdateResult {
+  code: number;
+  stderr: string;
+  stdout: string;
+}
+
+export function runPackageManagerUpdate(
+  manager: "bun" | "npm",
+  args: string[],
+  options: {
+    captureOutput?: boolean;
+    spawnImpl?: typeof spawnSync;
+  } = {}
+): PackageManagerUpdateResult {
+  const result = (options.spawnImpl ?? spawnSync)(manager, args, {
+    encoding: "utf8",
+    stdio: options.captureOutput ? "pipe" : "inherit",
     windowsHide: false,
   });
 
@@ -20,7 +34,11 @@ function runPackageManagerUpdate(manager: "bun" | "npm", args: string[]) {
     throw result.error;
   }
 
-  return typeof result.status === "number" ? result.status : 1;
+  return {
+    code: typeof result.status === "number" ? result.status : 1,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
 }
 
 export class SelfUpdateCommand extends AgentCommand {
@@ -101,11 +119,18 @@ export class SelfUpdateCommand extends AgentCommand {
     }
 
     try {
-      const code = runPackageManagerUpdate(plan.manager, plan.args);
-      if (code === 0 && format === "text") {
+      const result = runPackageManagerUpdate(plan.manager, plan.args, {
+        captureOutput: format !== "text",
+      });
+      if (format !== "text") {
+        writeStructured(this.context.stdout, format, {
+          plan,
+          result,
+        });
+      } else if (result.code === 0) {
         this.context.stdout.write("Update finished.\n");
       }
-      return code;
+      return result.code;
     } catch (error) {
       this.context.stderr.write(
         `Error: ${error instanceof Error ? error.message : String(error)}\n`

--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -1,0 +1,114 @@
+import { confirm } from "@clack/prompts";
+import { spawnSync } from "node:child_process";
+import { AgentCommand } from "../utils/agent-command.ts";
+import { Command, Option } from "../utils/option.ts";
+import {
+  executeStandaloneUpdate,
+  normalizePackageManager,
+  resolveUpdatePlan,
+} from "../utils/update.ts";
+import { writeStructured } from "../utils/output.ts";
+
+function runPackageManagerUpdate(manager: "bun" | "npm", args: string[]) {
+  const result = spawnSync(manager, args, {
+    stdio: "inherit",
+    windowsHide: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return typeof result.status === "number" ? result.status : 1;
+}
+
+export class SelfUpdateCommand extends AgentCommand {
+  static override paths = [["self", "update"]];
+
+  static override usage = Command.Usage({
+    description: "Update the installed Gambi CLI",
+    details:
+      "Detects the installation source and runs the matching upgrade path. Use --dry-run to preview the exact command.",
+    examples: [
+      ["Preview the update", "gambi self update --dry-run --format json"],
+      ["Run without confirmation", "gambi self update --yes"],
+    ],
+  });
+
+  manager = Option.String("--manager", {
+    description: "Preferred package manager (bun or npm)",
+    required: false,
+  });
+
+  yes = Option.Boolean("--yes", false, {
+    description: "Skip confirmation",
+  });
+
+  dryRun = Option.Boolean("--dry-run", false, {
+    description: "Print the resolved update plan and exit",
+  });
+
+  async execute(): Promise<number> {
+    if (this.manager && !normalizePackageManager(this.manager)) {
+      this.context.stderr.write(
+        "Error: Unsupported package manager.\nHint: use bun or npm.\n"
+      );
+      return 2;
+    }
+
+    const plan = resolveUpdatePlan({ manager: this.manager });
+    if (!plan) {
+      this.context.stderr.write(
+        "Error: Could not determine the install source.\nHint: rerun with --manager bun or --manager npm.\n"
+      );
+      return 3;
+    }
+
+    const format = this.resolveFormat(false);
+    if (this.dryRun) {
+      if (format === "text") {
+        this.context.stdout.write(`Would run: ${plan.command}\n`);
+      } else {
+        writeStructured(this.context.stdout, format, { plan });
+      }
+      return 0;
+    }
+
+    if (!this.yes && this.allowInteractive(true)) {
+      const shouldProceed = await confirm({
+        message: `Run update now?\n${plan.command}`,
+        initialValue: true,
+      });
+      if (!shouldProceed) {
+        this.context.stdout.write("Update cancelled.\n");
+        return 0;
+      }
+    }
+
+    if (plan.kind === "standalone") {
+      const result = await executeStandaloneUpdate(plan);
+      if (format !== "text") {
+        writeStructured(this.context.stdout, format, {
+          result,
+          plan,
+        });
+      } else {
+        this.context.stdout.write("Update finished.\n");
+      }
+      return 0;
+    }
+
+    try {
+      const code = runPackageManagerUpdate(plan.manager, plan.args);
+      if (code === 0 && format === "text") {
+        this.context.stdout.write("Update finished.\n");
+      }
+      return code;
+    } catch (error) {
+      this.context.stderr.write(
+        `Error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/utils/agent-command.ts
+++ b/packages/cli/src/utils/agent-command.ts
@@ -1,26 +1,14 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  type CliEnvironmentConfig,
+  loadCliConfig,
+  renderCliConfigError,
+  resolveEnvConfig,
+} from "./cli-config.ts";
 import { Command, Option } from "./option.ts";
 
 export type OutputFormat = "text" | "json" | "ndjson";
-
-export interface CliEnvironmentConfig {
-  endpoint?: string;
-  headers?: Record<string, string>;
-  hubUrl?: string;
-  networkEndpoint?: string;
-  noSpecs?: boolean;
-  serve?: {
-    host?: string;
-    mdns?: boolean;
-    port?: number;
-  };
-}
-
-export interface CliConfig {
-  defaultEnv?: string;
-  envs?: Record<string, CliEnvironmentConfig>;
-}
 
 export abstract class AgentCommand extends Command {
   format = Option.String("--format", {
@@ -57,6 +45,10 @@ export abstract class AgentCommand extends Command {
       requestedFormat === "json" ||
       requestedFormat === "ndjson"
     ) {
+      if (streaming && requestedFormat === "json") {
+        return "ndjson";
+      }
+
       return requestedFormat;
     }
 
@@ -65,6 +57,29 @@ export abstract class AgentCommand extends Command {
     }
 
     return "text";
+  }
+
+  protected resolveEnvName(): string | undefined {
+    return this.env ?? process.env.GAMBI_ENV ?? undefined;
+  }
+
+  protected async loadEnvConfig(): Promise<
+    | { ok: true; value: CliEnvironmentConfig | undefined }
+    | { exitCode: 2; ok: false }
+  > {
+    try {
+      const config = await loadCliConfig(this.resolveConfigPath());
+      return {
+        ok: true,
+        value: resolveEnvConfig(config, this.resolveEnvName()),
+      };
+    } catch (error) {
+      this.context.stderr.write(renderCliConfigError(error));
+      return {
+        ok: false,
+        exitCode: 2,
+      };
+    }
   }
 
   protected allowInteractive(defaultWhenTty = false): boolean {

--- a/packages/cli/src/utils/agent-command.ts
+++ b/packages/cli/src/utils/agent-command.ts
@@ -1,0 +1,87 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Command, Option } from "./option.ts";
+
+export type OutputFormat = "text" | "json" | "ndjson";
+
+export interface CliEnvironmentConfig {
+  endpoint?: string;
+  headers?: Record<string, string>;
+  hubUrl?: string;
+  networkEndpoint?: string;
+  noSpecs?: boolean;
+  serve?: {
+    host?: string;
+    mdns?: boolean;
+    port?: number;
+  };
+}
+
+export interface CliConfig {
+  defaultEnv?: string;
+  envs?: Record<string, CliEnvironmentConfig>;
+}
+
+export abstract class AgentCommand extends Command {
+  format = Option.String("--format", {
+    description: "Output format (text, json, ndjson)",
+    required: false,
+  });
+
+  env = Option.String("--env", {
+    description: "Named environment from the CLI config file",
+    required: false,
+  });
+
+  interactive = Option.Boolean("--interactive", false, {
+    description: "Allow interactive prompts for missing required values",
+  });
+
+  noInteractive = Option.Boolean("--no-interactive", false, {
+    description: "Disable all interactive prompts",
+  });
+
+  verbose = Option.Boolean("--verbose", false, {
+    description: "Include extended details in output",
+  });
+
+  quiet = Option.Boolean("--quiet", false, {
+    description: "Reduce non-essential text output",
+  });
+
+  protected resolveFormat(streaming = false): OutputFormat {
+    const requestedFormat =
+      this.format ?? process.env.GAMBI_FORMAT ?? undefined;
+    if (
+      requestedFormat === "text" ||
+      requestedFormat === "json" ||
+      requestedFormat === "ndjson"
+    ) {
+      return requestedFormat;
+    }
+
+    if (!process.stdout.isTTY) {
+      return streaming ? "ndjson" : "json";
+    }
+
+    return "text";
+  }
+
+  protected allowInteractive(defaultWhenTty = false): boolean {
+    if (this.noInteractive || process.env.GAMBI_NO_INTERACTIVE === "1") {
+      return false;
+    }
+
+    if (this.interactive) {
+      return !!process.stdin.isTTY && !!process.stdout.isTTY;
+    }
+
+    return defaultWhenTty && !!process.stdin.isTTY && !!process.stdout.isTTY;
+  }
+
+  protected resolveConfigPath(): string {
+    const xdgConfigHome =
+      process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+    return join(xdgConfigHome, "gambi", "config.json");
+  }
+}

--- a/packages/cli/src/utils/cli-config.ts
+++ b/packages/cli/src/utils/cli-config.ts
@@ -1,20 +1,61 @@
 import { resolve } from "node:path";
 import { RuntimeConfig } from "@gambi/core/types";
-import type {
-  CliConfig,
-  CliEnvironmentConfig,
-} from "./agent-command.ts";
+
+export interface CliEnvironmentConfig {
+  endpoint?: string;
+  headers?: Record<string, string>;
+  hubUrl?: string;
+  networkEndpoint?: string;
+  noSpecs?: boolean;
+  serve?: {
+    host?: string;
+    mdns?: boolean;
+    port?: number;
+  };
+}
+
+export interface CliConfig {
+  defaultEnv?: string;
+  envs?: Record<string, CliEnvironmentConfig>;
+}
+
+export class CliConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliConfigError";
+  }
+}
 
 export async function loadCliConfig(
   configPath: string
 ): Promise<CliConfig | undefined> {
-  const file = Bun.file(resolve(configPath));
+  const resolvedPath = resolve(configPath);
+  const file = Bun.file(resolvedPath);
   if (!(await file.exists())) {
     return undefined;
   }
 
-  const raw = JSON.parse(await file.text()) as CliConfig;
+  let raw: CliConfig;
+  try {
+    raw = JSON.parse(await file.text()) as CliConfig;
+  } catch (error) {
+    throw new CliConfigError(
+      `Invalid CLI config in ${resolvedPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
   return raw;
+}
+
+export function renderCliConfigError(error: unknown): string {
+  let message: string;
+  if (error instanceof CliConfigError || error instanceof Error) {
+    message = error.message;
+  } else {
+    message = String(error);
+  }
+
+  return `Error: ${message}\nHint: fix the config file or remove it and retry.\n`;
 }
 
 export async function loadRuntimeConfigFromInput(

--- a/packages/cli/src/utils/cli-config.ts
+++ b/packages/cli/src/utils/cli-config.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import { RuntimeConfig } from "@gambi/core/types";
+import type {
+  CliConfig,
+  CliEnvironmentConfig,
+} from "./agent-command.ts";
+
+export async function loadCliConfig(
+  configPath: string
+): Promise<CliConfig | undefined> {
+  const file = Bun.file(resolve(configPath));
+  if (!(await file.exists())) {
+    return undefined;
+  }
+
+  const raw = JSON.parse(await file.text()) as CliConfig;
+  return raw;
+}
+
+export async function loadRuntimeConfigFromInput(
+  inputPath?: string
+): Promise<RuntimeConfig | undefined> {
+  if (!inputPath) {
+    return undefined;
+  }
+
+  const rawText =
+    inputPath === "-"
+      ? await new Response(Bun.stdin.stream()).text()
+      : await Bun.file(resolve(inputPath)).text();
+  const parsed = RuntimeConfig.safeParse(JSON.parse(rawText));
+
+  if (!parsed.success) {
+    throw new Error(`Invalid runtime config: ${parsed.error.message}`);
+  }
+
+  return parsed.data;
+}
+
+export function resolveEnvConfig(
+  config: CliConfig | undefined,
+  envName?: string
+): CliEnvironmentConfig | undefined {
+  if (!config?.envs) {
+    return undefined;
+  }
+
+  const selectedEnv = envName ?? config.defaultEnv;
+  if (!selectedEnv) {
+    return undefined;
+  }
+
+  return config.envs[selectedEnv];
+}

--- a/packages/cli/src/utils/management-api.test.ts
+++ b/packages/cli/src/utils/management-api.test.ts
@@ -9,9 +9,8 @@ describe("management api helpers", () => {
   });
 
   test("requestManagement returns a structured connectivity failure when fetch rejects", async () => {
-    globalThis.fetch = (async () => {
-      throw new Error("connect ECONNREFUSED");
-    }) as unknown as typeof fetch;
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("connect ECONNREFUSED"))) as unknown as typeof fetch;
 
     const result = await requestManagement(
       "http://localhost:3000",
@@ -28,23 +27,53 @@ describe("management api helpers", () => {
     expect(result.value.error.hint).toBe("Check hub URL and connectivity.");
   });
 
-  test("watchRoomEvents flushes the final buffered SSE block", async () => {
+  test("requestManagement returns a protocol failure when success JSON is invalid", async () => {
     globalThis.fetch = (async () =>
-      new Response(new ReadableStream({
-        start(controller) {
-          controller.enqueue(
-            new TextEncoder().encode(
-              'event: participant.joined\ndata: {"type":"participant.joined","timestamp":1,"roomCode":"ABC123","data":{"id":"worker-1"}}'
-            )
-          );
-          controller.close();
-        },
-      }), {
-        headers: { "Content-Type": "text/event-stream" },
+      new Response("not-json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
       })) as unknown as typeof fetch;
 
+    const result = await requestManagement(
+      "http://localhost:3000",
+      "/v1/rooms"
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected a failure result");
+    }
+
+    expect(result.value.status).toBe(502);
+    expect(result.value.error.message).toBe("Invalid JSON response from hub.");
+    expect(result.value.error.hint).toBe(
+      "Check hub compatibility or proxy behavior."
+    );
+  });
+
+  test("watchRoomEvents flushes the final buffered SSE block", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                'event: participant.joined\ndata: {"type":"participant.joined","timestamp":1,"roomCode":"ABC123","data":{"id":"worker-1"}}'
+              )
+            );
+            controller.close();
+          },
+        }),
+        {
+          headers: { "Content-Type": "text/event-stream" },
+        }
+      )) as unknown as typeof fetch;
+
     const events: unknown[] = [];
-    for await (const event of watchRoomEvents("http://localhost:3000", "ABC123")) {
+    for await (const event of watchRoomEvents(
+      "http://localhost:3000",
+      "ABC123"
+    )) {
       events.push(event);
     }
 

--- a/packages/cli/src/utils/management-api.test.ts
+++ b/packages/cli/src/utils/management-api.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { requestManagement, watchRoomEvents } from "./management-api.ts";
+
+const originalFetch = globalThis.fetch;
+
+describe("management api helpers", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("requestManagement returns a structured connectivity failure when fetch rejects", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("connect ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const result = await requestManagement(
+      "http://localhost:3000",
+      "/v1/rooms"
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected a failure result");
+    }
+
+    expect(result.value.status).toBe(503);
+    expect(result.value.error.message).toBe("Failed to reach hub.");
+    expect(result.value.error.hint).toBe("Check hub URL and connectivity.");
+  });
+
+  test("watchRoomEvents flushes the final buffered SSE block", async () => {
+    globalThis.fetch = (async () =>
+      new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: participant.joined\ndata: {"type":"participant.joined","timestamp":1,"roomCode":"ABC123","data":{"id":"worker-1"}}'
+            )
+          );
+          controller.close();
+        },
+      }), {
+        headers: { "Content-Type": "text/event-stream" },
+      })) as unknown as typeof fetch;
+
+    const events: unknown[] = [];
+    for await (const event of watchRoomEvents("http://localhost:3000", "ABC123")) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      {
+        type: "participant.joined",
+        timestamp: 1,
+        roomCode: "ABC123",
+        data: { id: "worker-1" },
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/utils/management-api.test.ts
+++ b/packages/cli/src/utils/management-api.test.ts
@@ -10,7 +10,9 @@ describe("management api helpers", () => {
 
   test("requestManagement returns a structured connectivity failure when fetch rejects", async () => {
     globalThis.fetch = (() =>
-      Promise.reject(new Error("connect ECONNREFUSED"))) as unknown as typeof fetch;
+      Promise.reject(
+        new Error("connect ECONNREFUSED")
+      )) as unknown as typeof fetch;
 
     const result = await requestManagement(
       "http://localhost:3000",
@@ -85,5 +87,23 @@ describe("management api helpers", () => {
         data: { id: "worker-1" },
       },
     ]);
+  });
+
+  test("watchRoomEvents ends cleanly when aborted", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(
+        new DOMException("Aborted", "AbortError")
+      )) as unknown as typeof fetch;
+
+    const events: unknown[] = [];
+    for await (const event of watchRoomEvents(
+      "http://localhost:3000",
+      "ABC123",
+      AbortSignal.abort()
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([]);
   });
 });

--- a/packages/cli/src/utils/management-api.ts
+++ b/packages/cli/src/utils/management-api.ts
@@ -21,6 +21,12 @@ export class WatchRoomEventsError extends Error {
   }
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}
+
 function isApiSuccess<T>(value: unknown): value is ApiSuccess<T> {
   return (
     typeof value === "object" &&
@@ -189,7 +195,10 @@ export async function* watchRoomEvents(
       headers: { Accept: "text/event-stream" },
       signal,
     });
-  } catch {
+  } catch (error) {
+    if (isAbortError(error)) {
+      return;
+    }
     throw new WatchRoomEventsError(createConnectivityFailure());
   }
 
@@ -222,7 +231,17 @@ export async function* watchRoomEvents(
   let buffer = "";
 
   while (true) {
-    const { done, value } = await reader.read();
+    let chunk;
+    try {
+      chunk = await reader.read();
+    } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
+      throw new WatchRoomEventsError(createConnectivityFailure());
+    }
+
+    const { done, value } = chunk;
     if (done) {
       break;
     }

--- a/packages/cli/src/utils/management-api.ts
+++ b/packages/cli/src/utils/management-api.ts
@@ -1,11 +1,4 @@
-import type {
-  ApiErrorResponse,
-  ApiMeta,
-  HeartbeatResult,
-  ParticipantSummary,
-  RoomEvent,
-  RoomSummary,
-} from "@gambi/core/types";
+import type { ApiErrorResponse, ApiMeta, RoomEvent } from "@gambi/core/types";
 
 export interface ApiSuccess<T> {
   data: T;
@@ -18,11 +11,23 @@ export interface ApiFailure {
   meta?: ApiMeta;
 }
 
+export class WatchRoomEventsError extends Error {
+  readonly failure: ApiFailure;
+
+  constructor(failure: ApiFailure) {
+    super(failure.error.message);
+    this.name = "WatchRoomEventsError";
+    this.failure = failure;
+  }
+}
+
 export async function requestManagement<T>(
   hubUrl: string,
   path: string,
   init?: RequestInit
-): Promise<{ ok: true; value: ApiSuccess<T> } | { ok: false; value: ApiFailure }> {
+): Promise<
+  { ok: true; value: ApiSuccess<T> } | { ok: false; value: ApiFailure }
+> {
   const response = await fetch(`${hubUrl}${path}`, {
     ...init,
     headers: {
@@ -61,7 +66,11 @@ export function exitCodeForFailure(failure: ApiFailure): number {
     return 2;
   }
 
-  if (failure.status === 401 || failure.status === 403 || failure.status === 503) {
+  if (
+    failure.status === 401 ||
+    failure.status === 403 ||
+    failure.status === 503
+  ) {
     return 3;
   }
 
@@ -97,11 +106,24 @@ export async function* watchRoomEvents(
     const body = (await response.json().catch(() => undefined)) as
       | ApiErrorResponse
       | undefined;
-    throw new Error(body?.error?.message ?? response.statusText);
+    throw new WatchRoomEventsError({
+      status: response.status,
+      error: body?.error ?? {
+        code: "INTERNAL_ERROR",
+        message: response.statusText,
+      },
+      meta: body?.meta,
+    });
   }
 
   if (!response.body) {
-    throw new Error("Missing event stream body.");
+    throw new WatchRoomEventsError({
+      status: 502,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Missing event stream body.",
+      },
+    });
   }
 
   const reader = response.body.getReader();
@@ -129,10 +151,14 @@ export async function* watchRoomEvents(
       try {
         yield JSON.parse(payloadLine.slice(6)) as RoomEvent;
       } catch {
-        continue;
+        // Ignore malformed SSE payloads and continue consuming the stream.
       }
     }
   }
 }
 
-export type { HeartbeatResult, ParticipantSummary, RoomSummary };
+export type {
+  HeartbeatResult,
+  ParticipantSummary,
+  RoomSummary,
+} from "@gambi/core/types";

--- a/packages/cli/src/utils/management-api.ts
+++ b/packages/cli/src/utils/management-api.ts
@@ -1,0 +1,138 @@
+import type {
+  ApiErrorResponse,
+  ApiMeta,
+  HeartbeatResult,
+  ParticipantSummary,
+  RoomEvent,
+  RoomSummary,
+} from "@gambi/core/types";
+
+export interface ApiSuccess<T> {
+  data: T;
+  meta: ApiMeta;
+}
+
+export interface ApiFailure {
+  status: number;
+  error: NonNullable<ApiErrorResponse["error"]>;
+  meta?: ApiMeta;
+}
+
+export async function requestManagement<T>(
+  hubUrl: string,
+  path: string,
+  init?: RequestInit
+): Promise<{ ok: true; value: ApiSuccess<T> } | { ok: false; value: ApiFailure }> {
+  const response = await fetch(`${hubUrl}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+
+  const body = (await response.json().catch(() => undefined)) as
+    | ApiSuccess<T>
+    | ApiErrorResponse
+    | undefined;
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      value: {
+        status: response.status,
+        error: (body as ApiErrorResponse | undefined)?.error ?? {
+          code: "INTERNAL_ERROR",
+          message: response.statusText,
+        },
+        meta: (body as ApiErrorResponse | undefined)?.meta,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: body as ApiSuccess<T>,
+  };
+}
+
+export function exitCodeForFailure(failure: ApiFailure): number {
+  if (failure.status === 400 || failure.status === 422) {
+    return 2;
+  }
+
+  if (failure.status === 401 || failure.status === 403 || failure.status === 503) {
+    return 3;
+  }
+
+  if (failure.status === 404 || failure.status === 409) {
+    return 4;
+  }
+
+  return 1;
+}
+
+export function renderFailure(failure: ApiFailure): string {
+  const lines = [`Error: ${failure.error.message}`];
+  if (failure.error.hint) {
+    lines.push(`Hint: ${failure.error.hint}`);
+  }
+  if (failure.meta?.requestId) {
+    lines.push(`request_id: ${failure.meta.requestId}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function* watchRoomEvents(
+  hubUrl: string,
+  roomCode: string,
+  signal?: AbortSignal
+): AsyncIterable<RoomEvent> {
+  const response = await fetch(`${hubUrl}/v1/rooms/${roomCode}/events`, {
+    headers: { Accept: "text/event-stream" },
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => undefined)) as
+      | ApiErrorResponse
+      | undefined;
+    throw new Error(body?.error?.message ?? response.statusText);
+  }
+
+  if (!response.body) {
+    throw new Error("Missing event stream body.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const blocks = buffer.split("\n\n");
+    buffer = blocks.pop() ?? "";
+
+    for (const block of blocks) {
+      const payloadLine = block
+        .split("\n")
+        .find((line) => line.startsWith("data: "));
+      if (!payloadLine) {
+        continue;
+      }
+
+      try {
+        yield JSON.parse(payloadLine.slice(6)) as RoomEvent;
+      } catch {
+        continue;
+      }
+    }
+  }
+}
+
+export type { HeartbeatResult, ParticipantSummary, RoomSummary };

--- a/packages/cli/src/utils/management-api.ts
+++ b/packages/cli/src/utils/management-api.ts
@@ -21,6 +21,41 @@ export class WatchRoomEventsError extends Error {
   }
 }
 
+function createConnectivityFailure(
+  message = "Failed to reach hub.",
+  hint = "Check hub URL and connectivity."
+): ApiFailure {
+  return {
+    status: 503,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      hint,
+    },
+  };
+}
+
+function parseSseBlocks(chunk: string): RoomEvent[] {
+  const events: RoomEvent[] = [];
+
+  for (const block of chunk.split("\n\n")) {
+    const payloadLine = block
+      .split("\n")
+      .find((line) => line.startsWith("data: "));
+    if (!payloadLine) {
+      continue;
+    }
+
+    try {
+      events.push(JSON.parse(payloadLine.slice(6)) as RoomEvent);
+    } catch {
+      // Ignore malformed SSE payloads and continue consuming the stream.
+    }
+  }
+
+  return events;
+}
+
 export async function requestManagement<T>(
   hubUrl: string,
   path: string,
@@ -28,13 +63,21 @@ export async function requestManagement<T>(
 ): Promise<
   { ok: true; value: ApiSuccess<T> } | { ok: false; value: ApiFailure }
 > {
-  const response = await fetch(`${hubUrl}${path}`, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...init?.headers,
-    },
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${hubUrl}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers,
+      },
+    });
+  } catch {
+    return {
+      ok: false,
+      value: createConnectivityFailure(),
+    };
+  }
 
   const body = (await response.json().catch(() => undefined)) as
     | ApiSuccess<T>
@@ -97,10 +140,15 @@ export async function* watchRoomEvents(
   roomCode: string,
   signal?: AbortSignal
 ): AsyncIterable<RoomEvent> {
-  const response = await fetch(`${hubUrl}/v1/rooms/${roomCode}/events`, {
-    headers: { Accept: "text/event-stream" },
-    signal,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${hubUrl}/v1/rooms/${roomCode}/events`, {
+      headers: { Accept: "text/event-stream" },
+      signal,
+    });
+  } catch {
+    throw new WatchRoomEventsError(createConnectivityFailure());
+  }
 
   if (!response.ok) {
     const body = (await response.json().catch(() => undefined)) as
@@ -140,19 +188,14 @@ export async function* watchRoomEvents(
     const blocks = buffer.split("\n\n");
     buffer = blocks.pop() ?? "";
 
-    for (const block of blocks) {
-      const payloadLine = block
-        .split("\n")
-        .find((line) => line.startsWith("data: "));
-      if (!payloadLine) {
-        continue;
-      }
+    for (const event of parseSseBlocks(blocks.join("\n\n"))) {
+      yield event;
+    }
+  }
 
-      try {
-        yield JSON.parse(payloadLine.slice(6)) as RoomEvent;
-      } catch {
-        // Ignore malformed SSE payloads and continue consuming the stream.
-      }
+  if (buffer.trim()) {
+    for (const event of parseSseBlocks(buffer)) {
+      yield event;
     }
   }
 }

--- a/packages/cli/src/utils/management-api.ts
+++ b/packages/cli/src/utils/management-api.ts
@@ -21,6 +21,15 @@ export class WatchRoomEventsError extends Error {
   }
 }
 
+function isApiSuccess<T>(value: unknown): value is ApiSuccess<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    "meta" in value
+  );
+}
+
 function createConnectivityFailure(
   message = "Failed to reach hub.",
   hint = "Check hub URL and connectivity."
@@ -33,6 +42,33 @@ function createConnectivityFailure(
       hint,
     },
   };
+}
+
+function createProtocolFailure(
+  message = "Invalid JSON response from hub.",
+  hint = "Check hub compatibility or proxy behavior."
+): ApiFailure {
+  return {
+    status: 502,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      hint,
+    },
+  };
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
 }
 
 function parseSseBlocks(chunk: string): RoomEvent[] {
@@ -79,7 +115,7 @@ export async function requestManagement<T>(
     };
   }
 
-  const body = (await response.json().catch(() => undefined)) as
+  const body = (await readJsonBody(response)) as
     | ApiSuccess<T>
     | ApiErrorResponse
     | undefined;
@@ -98,9 +134,16 @@ export async function requestManagement<T>(
     };
   }
 
+  if (!isApiSuccess<T>(body)) {
+    return {
+      ok: false,
+      value: createProtocolFailure(),
+    };
+  }
+
   return {
     ok: true,
-    value: body as ApiSuccess<T>,
+    value: body,
   };
 }
 
@@ -193,6 +236,7 @@ export async function* watchRoomEvents(
     }
   }
 
+  buffer += decoder.decode();
   if (buffer.trim()) {
     for (const event of parseSseBlocks(buffer)) {
       yield event;

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -1,0 +1,14 @@
+import type { OutputFormat } from "./agent-command.ts";
+
+export function writeStructured(
+  stdout: NodeJS.WritableStream,
+  format: OutputFormat,
+  value: unknown
+): void {
+  if (format === "ndjson") {
+    stdout.write(`${JSON.stringify(value)}\n`);
+    return;
+  }
+
+  stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}

--- a/packages/cli/src/utils/room-discovery.test.ts
+++ b/packages/cli/src/utils/room-discovery.test.ts
@@ -11,6 +11,7 @@ const alphaRoom = {
   hostId: "host-alpha",
   createdAt: 1,
   participantCount: 2,
+  passwordProtected: false,
 };
 
 const betaRoom = {
@@ -20,6 +21,7 @@ const betaRoom = {
   hostId: "host-beta",
   createdAt: 2,
   participantCount: 1,
+  passwordProtected: false,
 };
 
 function createBrowseServices(services: DiscoveredService[]) {
@@ -37,14 +39,14 @@ describe("room discovery", () => {
     const fetchFn: NonNullable<FetchLike> = (input) => {
       const url = String(input);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://localhost:3000/rooms") {
-        return Promise.resolve(Response.json({ rooms: [alphaRoom] }));
+      if (url === "http://localhost:3000/v1/rooms") {
+        return Promise.resolve(Response.json({ data: [alphaRoom] }));
       }
 
       throw new Error(`Unexpected URL: ${url}`);
@@ -75,24 +77,24 @@ describe("room discovery", () => {
       const url = String(input);
       fetchCalls.push(url);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://localhost:3000/rooms") {
-        return Promise.resolve(Response.json({ rooms: [alphaRoom] }));
+      if (url === "http://localhost:3000/v1/rooms") {
+        return Promise.resolve(Response.json({ data: [alphaRoom] }));
       }
 
-      if (url === "http://192.168.1.40:3100/health") {
+      if (url === "http://192.168.1.40:3100/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://192.168.1.40:3100/rooms") {
-        return Promise.resolve(Response.json({ rooms: [betaRoom] }));
+      if (url === "http://192.168.1.40:3100/v1/rooms") {
+        return Promise.resolve(Response.json({ data: [betaRoom] }));
       }
 
       throw new Error(`Unexpected URL: ${url}`);
@@ -114,10 +116,10 @@ describe("room discovery", () => {
     });
 
     expect(fetchCalls).toEqual([
-      "http://localhost:3000/health",
-      "http://192.168.1.40:3100/health",
-      "http://localhost:3000/rooms",
-      "http://192.168.1.40:3100/rooms",
+      "http://localhost:3000/v1/health",
+      "http://192.168.1.40:3100/v1/health",
+      "http://localhost:3000/v1/rooms",
+      "http://192.168.1.40:3100/v1/rooms",
     ]);
     expect(rooms).toEqual([
       {
@@ -139,26 +141,26 @@ describe("room discovery", () => {
     const fetchFn: NonNullable<FetchLike> = (input) => {
       const url = String(input);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://localhost:3000/rooms") {
-        return Promise.resolve(Response.json({ rooms: [alphaRoom] }));
+      if (url === "http://localhost:3000/v1/rooms") {
+        return Promise.resolve(Response.json({ data: [alphaRoom] }));
       }
 
-      if (url === "http://192.168.1.50:3000/health") {
+      if (url === "http://192.168.1.50:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://192.168.1.50:3000/rooms") {
+      if (url === "http://192.168.1.50:3000/v1/rooms") {
         return Promise.resolve(
           Response.json({
-            rooms: [{ ...alphaRoom, name: "Alpha duplicate" }],
+            data: [{ ...alphaRoom, name: "Alpha duplicate" }],
           })
         );
       }
@@ -197,24 +199,24 @@ describe("room discovery", () => {
       const url = String(input);
       fetchCalls.push(url);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://localhost:3000/rooms") {
-        return Promise.resolve(Response.json({ rooms: [] }));
+      if (url === "http://localhost:3000/v1/rooms") {
+        return Promise.resolve(Response.json({ data: [] }));
       }
 
-      if (url === "http://192.168.1.60:3200/health") {
+      if (url === "http://192.168.1.60:3200/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({ data: { status: "ok", timestamp: Date.now() } })
         );
       }
 
-      if (url === "http://192.168.1.60:3200/rooms") {
-        return Promise.resolve(Response.json({ rooms: [betaRoom] }));
+      if (url === "http://192.168.1.60:3200/v1/rooms") {
+        return Promise.resolve(Response.json({ data: [betaRoom] }));
       }
 
       throw new Error(`Unexpected URL: ${url}`);
@@ -236,10 +238,10 @@ describe("room discovery", () => {
     });
 
     expect(fetchCalls).toEqual([
-      "http://localhost:3000/health",
-      "http://192.168.1.60:3200/health",
-      "http://localhost:3000/rooms",
-      "http://192.168.1.60:3200/rooms",
+      "http://localhost:3000/v1/health",
+      "http://192.168.1.60:3200/v1/health",
+      "http://localhost:3000/v1/rooms",
+      "http://192.168.1.60:3200/v1/rooms",
     ]);
     expect(rooms).toEqual([
       {

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -1,5 +1,5 @@
 import { type DiscoveredService, mDNS } from "./mdns.ts";
-import type { RoomInfoPublic } from "./types.ts";
+import type { RoomSummary } from "./types.ts";
 
 const DEFAULT_HUB_NAME = "Configured hub";
 const DEFAULT_HUB_URL = "http://localhost:3000";
@@ -14,17 +14,15 @@ type BrowseServicesLike = (
   callback: (service: DiscoveredService) => void
 ) => (() => void | Promise<void>) | void | Promise<void>;
 
-interface RoomInfoWithParticipantCount extends RoomInfoPublic {
-  participantCount: number;
-}
-
 interface HealthResponse {
-  status: string;
-  timestamp: number;
+  data: {
+    status: string;
+    timestamp: number;
+  };
 }
 
 interface ListRoomsResponse {
-  rooms: RoomInfoWithParticipantCount[];
+  data: RoomSummary[];
 }
 
 export interface DiscoveredHub {
@@ -37,7 +35,7 @@ export interface DiscoveredHub {
   txt: Record<string, string>;
 }
 
-export interface DiscoveredRoom extends RoomInfoWithParticipantCount {
+export interface DiscoveredRoom extends RoomSummary {
   hubName: string;
   hubSource: DiscoveredHub["source"];
   hubUrl: string;
@@ -134,7 +132,7 @@ async function fetchHubHealth(
   fetchFn: FetchLike
 ): Promise<HealthResponse | null> {
   try {
-    const response = await fetchFn(`${hubUrl}/health`);
+    const response = await fetchFn(`${hubUrl}/v1/health`);
     if (!response.ok) {
       return null;
     }
@@ -148,15 +146,15 @@ async function fetchHubHealth(
 async function fetchRoomsFromHub(
   hubUrl: string,
   fetchFn: FetchLike
-): Promise<RoomInfoWithParticipantCount[] | null> {
+): Promise<RoomSummary[] | null> {
   try {
-    const response = await fetchFn(`${hubUrl}/rooms`);
+    const response = await fetchFn(`${hubUrl}/v1/rooms`);
     if (!response.ok) {
       return null;
     }
 
     const data = (await response.json()) as ListRoomsResponse;
-    return Array.isArray(data.rooms) ? data.rooms : [];
+    return Array.isArray(data.data) ? data.data : [];
   } catch {
     return null;
   }

--- a/packages/core/src/endpoint-capabilities.ts
+++ b/packages/core/src/endpoint-capabilities.ts
@@ -44,6 +44,8 @@ async function probePostEndpoint(
     });
 
     if (
+      response.status === 401 ||
+      response.status === 403 ||
       response.status === 404 ||
       response.status === 405 ||
       response.status === 501

--- a/packages/core/src/hub.test.ts
+++ b/packages/core/src/hub.test.ts
@@ -9,6 +9,7 @@ import {
 import { z } from "zod";
 import { createHub, type Hub } from "./hub.ts";
 import { Room } from "./room.ts";
+import type { RoomEvent } from "./types.ts";
 
 const ApiMetaSchema = z.object({
   requestId: z.string(),
@@ -532,6 +533,68 @@ describe("Hub", () => {
     return { res, data: await res.json() };
   }
 
+  async function connectRoomEvents(roomCode: string) {
+    const controller = new AbortController();
+    const res = await fetch(`${baseUrl}/v1/rooms/${roomCode}/events`, {
+      signal: controller.signal,
+    });
+    const reader = res.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected an SSE response body.");
+    }
+
+    const decoder = new TextDecoder();
+    const queuedEvents: RoomEvent[] = [];
+    let buffer = "";
+
+    return {
+      close: async () => {
+        controller.abort();
+        try {
+          await reader.cancel();
+        } catch {
+          // The stream can already be closed by the time cleanup runs.
+        }
+      },
+      nextEvent: async () => {
+        if (queuedEvents[0]) {
+          return queuedEvents.shift() as RoomEvent;
+        }
+
+        while (true) {
+          const { done, value } = await Promise.race([
+            reader.read(),
+            new Promise<never>((_, reject) => {
+              setTimeout(() => reject(new Error("Timed out waiting for room event.")), 1000);
+            }),
+          ]);
+          if (done) {
+            throw new Error("Event stream closed before the expected event arrived.");
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const blocks = buffer.split("\n\n");
+          buffer = blocks.pop() ?? "";
+
+          for (const block of blocks) {
+            const payloadLine = block
+              .split("\n")
+              .find((line) => line.startsWith("data: "));
+            if (!payloadLine) {
+              continue;
+            }
+
+            queuedEvents.push(JSON.parse(payloadLine.slice(6)) as RoomEvent);
+          }
+
+          if (queuedEvents[0]) {
+            return queuedEvents.shift() as RoomEvent;
+          }
+        }
+      },
+    };
+  }
+
   describe("mDNS", () => {
     test("starts and stops with mDNS enabled", () => {
       const mdnsHub = createHub({
@@ -936,6 +999,56 @@ describe("Hub", () => {
 
       expect(res.status).toBe(200);
       expect(data.data).toHaveLength(0);
+    });
+  });
+
+  describe("LLM lifecycle events", () => {
+    test("emits llm.complete after a successful non-streaming responses request", async () => {
+      const participantEndpoint = createMockParticipantServer("responses");
+      try {
+        const {
+          data: { room },
+        } = await createRoom("Responses Events Room");
+        await joinRoom(room.code, {
+          id: "participant-events",
+          nickname: "events-worker",
+          model: "llama3",
+          endpoint: participantEndpoint.url,
+        });
+
+        const events = await connectRoomEvents(room.code);
+        try {
+          const connectedEvent = await events.nextEvent();
+          expect(connectedEvent.type).toBe("connected");
+
+          const response = await fetch(`${baseUrl}/rooms/${room.code}/v1/responses`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              model: "participant-events",
+              input: "Hello",
+            }),
+          });
+          expect(response.status).toBe(200);
+
+          const requestEvent = await events.nextEvent();
+          const completeEvent = await events.nextEvent();
+
+          expect(requestEvent.type).toBe("llm.request");
+          expect(requestEvent.data).toEqual({
+            participantId: "participant-events",
+            model: "participant-events",
+          });
+          expect(completeEvent.type).toBe("llm.complete");
+          expect(completeEvent.data).toEqual({
+            participantId: "participant-events",
+          });
+        } finally {
+          await events.close();
+        }
+      } finally {
+        participantEndpoint.close();
+      }
     });
   });
 

--- a/packages/core/src/hub.test.ts
+++ b/packages/core/src/hub.test.ts
@@ -76,7 +76,7 @@ const JoinResponseSchema = successSchema(
       }),
     }),
     roomId: z.string(),
-  }),
+  })
 );
 
 const SuccessResponseSchema = successSchema(
@@ -584,6 +584,20 @@ describe("Hub", () => {
       expect(data.error.code).toBe("INVALID_REQUEST");
     });
 
+    test("returns typed error when the body is invalid JSON", async () => {
+      const res = await fetch(`${baseUrl}/v1/rooms`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{",
+      });
+      const data = ErrorResponseSchema.parse(await res.json());
+
+      expect(res.status).toBe(400);
+      expect(data.error.code).toBe("INVALID_REQUEST");
+      expect(data.error.message).toBe("Invalid JSON body.");
+      expect(data.meta.requestId).toBeDefined();
+    });
+
     test("accepts room defaults and redacts instructions in public responses", async () => {
       const { data } = await createRoom("Configured Room", {
         instructions: "Room-level system prompt",
@@ -670,6 +684,24 @@ describe("Hub", () => {
       expect(data.error.code).toBe("INVALID_REQUEST");
     });
 
+    test("returns typed error when the participant payload is invalid JSON", async () => {
+      const { data: created } = await createRoom("Test Room");
+      const res = await fetch(
+        `${baseUrl}/v1/rooms/${created.room.code}/participants/participant-1`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: "{",
+        }
+      );
+      const data = ErrorResponseSchema.parse(await res.json());
+
+      expect(res.status).toBe(400);
+      expect(data.error.code).toBe("INVALID_REQUEST");
+      expect(data.error.message).toBe("Invalid JSON body.");
+      expect(data.meta.requestId).toBeDefined();
+    });
+
     test("rejects loopback endpoints when the participant joins remotely", async () => {
       const { data: created } = await createRoom("Remote Room");
       const { res, data } = await joinRoom(
@@ -711,7 +743,9 @@ describe("Hub", () => {
         temperature: 0.5,
         max_tokens: 256,
       });
-      expect(joinData.data.participant.config).not.toHaveProperty("instructions");
+      expect(joinData.data.participant.config).not.toHaveProperty(
+        "instructions"
+      );
 
       const participantsResponse = await fetch(
         `${baseUrl}/v1/rooms/${created.room.code}/participants`
@@ -835,6 +869,17 @@ describe("Hub", () => {
 
       expect(res.status).toBe(404);
       expect(data.error.code).toBe("ROOM_NOT_FOUND");
+    });
+  });
+
+  describe("GET /v1/rooms/:code/events", () => {
+    test("returns a typed 404 envelope for missing rooms", async () => {
+      const res = await fetch(`${baseUrl}/v1/rooms/XXXXXX/events`);
+      const data = ErrorResponseSchema.parse(await res.json());
+
+      expect(res.status).toBe(404);
+      expect(data.error.code).toBe("ROOM_NOT_FOUND");
+      expect(data.meta.requestId).toBeDefined();
     });
   });
 

--- a/packages/core/src/hub.test.ts
+++ b/packages/core/src/hub.test.ts
@@ -10,53 +10,83 @@ import { z } from "zod";
 import { createHub, type Hub } from "./hub.ts";
 import { Room } from "./room.ts";
 
-const HealthResponseSchema = z.object({
-  status: z.string(),
-  timestamp: z.number(),
+const ApiMetaSchema = z.object({
+  requestId: z.string(),
 });
 
-const RoomResponseSchema = z.object({
-  room: z.object({
-    id: z.string(),
-    code: z.string(),
-    name: z.string(),
-    defaults: z
-      .object({
-        hasInstructions: z.boolean(),
-        temperature: z.number().optional(),
-      })
-      .optional(),
-  }),
-  hostId: z.string(),
+function successSchema<T extends z.ZodType>(schema: T) {
+  return z.object({
+    data: schema,
+    meta: ApiMetaSchema,
+  });
+}
+
+const HealthResponseSchema = successSchema(
+  z.object({
+    status: z.string(),
+    timestamp: z.number(),
+  })
+);
+
+const RoomSummarySchema = z.object({
+  id: z.string(),
+  code: z.string(),
+  name: z.string(),
+  passwordProtected: z.boolean(),
+  participantCount: z.number(),
+  defaults: z
+    .object({
+      hasInstructions: z.boolean(),
+      temperature: z.number().optional(),
+    })
+    .optional(),
 });
+
+const RoomResponseSchema = successSchema(
+  z.object({
+    room: RoomSummarySchema,
+    hostId: z.string(),
+  })
+);
 
 const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    hint: z.string().optional(),
+  }),
+  meta: ApiMetaSchema,
+});
+
+const LegacyErrorResponseSchema = z.object({
   error: z.string(),
 });
 
-const RoomsListResponseSchema = z.object({
-  rooms: z.array(z.object({ participantCount: z.number() })),
-});
+const RoomsListResponseSchema = successSchema(z.array(RoomSummarySchema));
 
-const JoinResponseSchema = z.object({
-  participant: z.object({
-    id: z.string(),
-    nickname: z.string(),
-    config: z.object({
-      hasInstructions: z.boolean(),
-      temperature: z.number().optional(),
-      max_tokens: z.number().optional(),
+const JoinResponseSchema = successSchema(
+  z.object({
+    participant: z.object({
+      id: z.string(),
+      nickname: z.string(),
+      config: z.object({
+        hasInstructions: z.boolean(),
+        temperature: z.number().optional(),
+        max_tokens: z.number().optional(),
+      }),
     }),
+    roomId: z.string(),
   }),
-  roomId: z.string(),
-});
+);
 
-const SuccessResponseSchema = z.object({
-  success: z.boolean(),
-});
+const SuccessResponseSchema = successSchema(
+  z.object({
+    success: z.boolean(),
+  })
+);
 
-const ParticipantsResponseSchema = z.object({
-  participants: z.array(
+const ParticipantsResponseSchema = successSchema(
+  z.array(
     z.object({
       nickname: z.string(),
       config: z.object({
@@ -65,8 +95,8 @@ const ParticipantsResponseSchema = z.object({
         max_tokens: z.number().optional(),
       }),
     })
-  ),
-});
+  )
+);
 
 const ModelsResponseSchema = z.object({
   object: z.string(),
@@ -460,7 +490,7 @@ describe("Hub", () => {
       temperature?: number;
     }
   ) {
-    const res = await fetch(`${baseUrl}/rooms`, {
+    const res = await fetch(`${baseUrl}/v1/rooms`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ defaults, name }),
@@ -488,14 +518,17 @@ describe("Hub", () => {
     },
     headers?: Record<string, string>
   ) {
-    const res = await fetch(`${baseUrl}/rooms/${code}/join`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...headers,
-      },
-      body: JSON.stringify(participant),
-    });
+    const res = await fetch(
+      `${baseUrl}/v1/rooms/${code}/participants/${participant.id}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          ...headers,
+        },
+        body: JSON.stringify(participant),
+      }
+    );
     return { res, data: await res.json() };
   }
 
@@ -513,20 +546,20 @@ describe("Hub", () => {
     });
   });
 
-  describe("GET /health", () => {
+  describe("GET /v1/health", () => {
     test("returns health status", async () => {
-      const res = await fetch(`${baseUrl}/health`);
+      const res = await fetch(`${baseUrl}/v1/health`);
       const data = HealthResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(200);
-      expect(data.status).toBe("ok");
-      expect(data.timestamp).toBeDefined();
+      expect(data.data.status).toBe("ok");
+      expect(data.data.timestamp).toBeDefined();
     });
   });
 
-  describe("POST /rooms", () => {
+  describe("POST /v1/rooms", () => {
     test("creates a new room", async () => {
-      const res = await fetch(`${baseUrl}/rooms`, {
+      const res = await fetch(`${baseUrl}/v1/rooms`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "Test Room" }),
@@ -534,13 +567,13 @@ describe("Hub", () => {
       const data = RoomResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(201);
-      expect(data.room.name).toBe("Test Room");
-      expect(data.room.code).toHaveLength(6);
-      expect(data.hostId).toBeDefined();
+      expect(data.data.room.name).toBe("Test Room");
+      expect(data.data.room.code).toHaveLength(6);
+      expect(data.data.hostId).toBeDefined();
     });
 
     test("returns error when name is missing", async () => {
-      const res = await fetch(`${baseUrl}/rooms`, {
+      const res = await fetch(`${baseUrl}/v1/rooms`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -548,51 +581,51 @@ describe("Hub", () => {
       const data = ErrorResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(400);
-      expect(data.error).toBe("Name is required");
+      expect(data.error.code).toBe("INVALID_REQUEST");
     });
 
     test("accepts room defaults and redacts instructions in public responses", async () => {
-      const { room } = await createRoom("Configured Room", {
+      const { data } = await createRoom("Configured Room", {
         instructions: "Room-level system prompt",
         temperature: 0.3,
       });
 
-      expect(room.defaults).toEqual({
+      expect(data.room.defaults).toEqual({
         hasInstructions: true,
         temperature: 0.3,
       });
-      expect(room.defaults).not.toHaveProperty("instructions");
+      expect(data.room.defaults).not.toHaveProperty("instructions");
     });
   });
 
-  describe("GET /rooms", () => {
+  describe("GET /v1/rooms", () => {
     test("returns empty list when no rooms", async () => {
-      const res = await fetch(`${baseUrl}/rooms`);
+      const res = await fetch(`${baseUrl}/v1/rooms`);
       const data = RoomsListResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(200);
-      expect(data.rooms).toEqual([]);
+      expect(data.data).toEqual([]);
     });
 
     test("returns list of rooms with participant count", async () => {
       await createRoom("Room 1");
       await createRoom("Room 2");
 
-      const res = await fetch(`${baseUrl}/rooms`);
+      const res = await fetch(`${baseUrl}/v1/rooms`);
       const data = RoomsListResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(200);
-      expect(data.rooms).toHaveLength(2);
-      const firstRoom = data.rooms[0];
+      expect(data.data).toHaveLength(2);
+      const firstRoom = data.data[0];
       expect(firstRoom).toBeDefined();
       expect(firstRoom?.participantCount).toBe(0);
     });
   });
 
-  describe("POST /rooms/:code/join", () => {
+  describe("PUT /v1/rooms/:code/participants/:id", () => {
     test("joins a room", async () => {
-      const { room } = await createRoom("Test Room");
-      const { res, data } = await joinRoom(room.code, {
+      const { data: created } = await createRoom("Test Room");
+      const { res, data } = await joinRoom(created.room.code, {
         id: "participant-1",
         nickname: "test-user",
         model: "llama3",
@@ -601,11 +634,11 @@ describe("Hub", () => {
 
       expect(res.status).toBe(201);
       const joinData = JoinResponseSchema.parse(data);
-      expect(joinData.participant.id).toBe("participant-1");
-      expect(joinData.participant.nickname).toBe("test-user");
-      expect(joinData.roomId).toBe(room.id);
-      expect("authHeaders" in joinData.participant).toBe(false);
-      expect(joinData.participant.config.hasInstructions).toBe(false);
+      expect(joinData.data.participant.id).toBe("participant-1");
+      expect(joinData.data.participant.nickname).toBe("test-user");
+      expect(joinData.data.roomId).toBe(created.room.id);
+      expect("authHeaders" in joinData.data.participant).toBe(false);
+      expect(joinData.data.participant.config.hasInstructions).toBe(false);
     });
 
     test("returns error for non-existent room", async () => {
@@ -618,26 +651,29 @@ describe("Hub", () => {
 
       expect(res.status).toBe(404);
       const errorData = ErrorResponseSchema.parse(data);
-      expect(errorData.error).toBe("Room not found");
+      expect(errorData.error.code).toBe("ROOM_NOT_FOUND");
     });
 
     test("returns error when required fields are missing", async () => {
-      const { room } = await createRoom("Test Room");
-      const res = await fetch(`${baseUrl}/rooms/${room.code}/join`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: "participant-1" }),
-      });
+      const { data: created } = await createRoom("Test Room");
+      const res = await fetch(
+        `${baseUrl}/v1/rooms/${created.room.code}/participants/participant-1`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }
+      );
       const data = ErrorResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(400);
-      expect(data.error).toContain("Missing required fields");
+      expect(data.error.code).toBe("INVALID_REQUEST");
     });
 
     test("rejects loopback endpoints when the participant joins remotely", async () => {
-      const { room } = await createRoom("Remote Room");
+      const { data: created } = await createRoom("Remote Room");
       const { res, data } = await joinRoom(
-        room.code,
+        created.room.code,
         {
           id: "participant-remote",
           nickname: "remote-user",
@@ -649,15 +685,15 @@ describe("Hub", () => {
 
       expect(res.status).toBe(400);
       const errorData = ErrorResponseSchema.parse(data);
-      expect(errorData.error).toContain(
+      expect(errorData.error.message).toContain(
         "only reachable on the participant machine"
       );
-      expect(errorData.error).toContain("--network-endpoint");
+      expect(errorData.error.hint).toContain("--network-endpoint");
     });
 
     test("redacts participant instructions in join and list responses", async () => {
-      const { room } = await createRoom("Test Room");
-      const { data } = await joinRoom(room.code, {
+      const { data: created } = await createRoom("Test Room");
+      const { data } = await joinRoom(created.room.code, {
         id: "participant-redacted",
         nickname: "config-user",
         model: "llama3",
@@ -670,34 +706,34 @@ describe("Hub", () => {
       });
 
       const joinData = JoinResponseSchema.parse(data);
-      expect(joinData.participant.config).toEqual({
+      expect(joinData.data.participant.config).toEqual({
         hasInstructions: true,
         temperature: 0.5,
         max_tokens: 256,
       });
-      expect(joinData.participant.config).not.toHaveProperty("instructions");
+      expect(joinData.data.participant.config).not.toHaveProperty("instructions");
 
       const participantsResponse = await fetch(
-        `${baseUrl}/rooms/${room.code}/participants`
+        `${baseUrl}/v1/rooms/${created.room.code}/participants`
       );
       const participantsData = ParticipantsResponseSchema.parse(
         await participantsResponse.json()
       );
-      expect(participantsData.participants[0]?.config).toEqual({
+      expect(participantsData.data[0]?.config).toEqual({
         hasInstructions: true,
         temperature: 0.5,
         max_tokens: 256,
       });
-      expect(participantsData.participants[0]?.config).not.toHaveProperty(
+      expect(participantsData.data[0]?.config).not.toHaveProperty(
         "instructions"
       );
     });
   });
 
-  describe("DELETE /rooms/:code/leave/:id", () => {
+  describe("DELETE /v1/rooms/:code/participants/:id", () => {
     test("removes participant from room", async () => {
-      const { room } = await createRoom("Test Room");
-      await joinRoom(room.code, {
+      const { data: created } = await createRoom("Test Room");
+      await joinRoom(created.room.code, {
         id: "participant-1",
         nickname: "test-user",
         model: "llama3",
@@ -705,96 +741,108 @@ describe("Hub", () => {
       });
 
       const res = await fetch(
-        `${baseUrl}/rooms/${room.code}/leave/participant-1`,
+        `${baseUrl}/v1/rooms/${created.room.code}/participants/participant-1`,
         { method: "DELETE" }
       );
       const data = SuccessResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(200);
-      expect(data.success).toBe(true);
+      expect(data.data.success).toBe(true);
     });
 
     test("returns error for non-existent participant", async () => {
-      const { room } = await createRoom("Test Room");
+      const { data: created } = await createRoom("Test Room");
       const res = await fetch(
-        `${baseUrl}/rooms/${room.code}/leave/non-existent`,
+        `${baseUrl}/v1/rooms/${created.room.code}/participants/non-existent`,
         { method: "DELETE" }
       );
       const data = ErrorResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(404);
-      expect(data.error).toBe("Participant not found");
+      expect(data.error.code).toBe("PARTICIPANT_NOT_FOUND");
     });
   });
 
-  describe("POST /rooms/:code/health", () => {
+  describe("POST /v1/rooms/:code/participants/:id/heartbeat", () => {
     test("updates participant last seen", async () => {
-      const { room } = await createRoom("Test Room");
-      await joinRoom(room.code, {
+      const { data: created } = await createRoom("Test Room");
+      await joinRoom(created.room.code, {
         id: "participant-1",
         nickname: "test-user",
         model: "llama3",
         endpoint: "http://localhost:11434",
       });
 
-      const res = await fetch(`${baseUrl}/rooms/${room.code}/health`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: "participant-1" }),
-      });
-      const data = SuccessResponseSchema.parse(await res.json());
+      const res = await fetch(
+        `${baseUrl}/v1/rooms/${created.room.code}/participants/participant-1/heartbeat`,
+        {
+          method: "POST",
+        }
+      );
+      const data = successSchema(
+        z.object({
+          success: z.literal(true),
+          status: z.string(),
+          lastSeen: z.number(),
+        })
+      ).parse(await res.json());
 
       expect(res.status).toBe(200);
-      expect(data.success).toBe(true);
+      expect(data.data.success).toBe(true);
     });
 
     test("returns error for non-existent participant", async () => {
-      const { room } = await createRoom("Test Room");
-      const res = await fetch(`${baseUrl}/rooms/${room.code}/health`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: "non-existent" }),
-      });
+      const { data: created } = await createRoom("Test Room");
+      const res = await fetch(
+        `${baseUrl}/v1/rooms/${created.room.code}/participants/non-existent/heartbeat`,
+        {
+          method: "POST",
+        }
+      );
       const data = ErrorResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(404);
-      expect(data.error).toBe("Participant not found");
+      expect(data.error.code).toBe("PARTICIPANT_NOT_FOUND");
     });
   });
 
-  describe("GET /rooms/:code/participants", () => {
+  describe("GET /v1/rooms/:code/participants", () => {
     test("returns participants in room", async () => {
-      const { room } = await createRoom("Test Room");
-      await joinRoom(room.code, {
+      const { data: created } = await createRoom("Test Room");
+      await joinRoom(created.room.code, {
         id: "participant-1",
         nickname: "test-user",
         model: "llama3",
         endpoint: "http://localhost:11434",
       });
 
-      const res = await fetch(`${baseUrl}/rooms/${room.code}/participants`);
+      const res = await fetch(
+        `${baseUrl}/v1/rooms/${created.room.code}/participants`
+      );
       const data = ParticipantsResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(200);
-      expect(data.participants).toHaveLength(1);
-      const firstParticipant = data.participants[0];
+      expect(data.data).toHaveLength(1);
+      const firstParticipant = data.data[0];
       expect(firstParticipant).toBeDefined();
       expect(firstParticipant?.nickname).toBe("test-user");
       expect(firstParticipant).not.toHaveProperty("authHeaders");
     });
 
     test("returns error for non-existent room", async () => {
-      const res = await fetch(`${baseUrl}/rooms/XXXXXX/participants`);
+      const res = await fetch(`${baseUrl}/v1/rooms/XXXXXX/participants`);
       const data = ErrorResponseSchema.parse(await res.json());
 
       expect(res.status).toBe(404);
-      expect(data.error).toBe("Room not found");
+      expect(data.error.code).toBe("ROOM_NOT_FOUND");
     });
   });
 
   describe("GET /rooms/:code/v1/models", () => {
     test("returns OpenAI-compatible models list", async () => {
-      const { room } = await createRoom("Test Room");
+      const {
+        data: { room },
+      } = await createRoom("Test Room");
       await joinRoom(room.code, {
         id: "participant-1",
         nickname: "test-user",
@@ -825,7 +873,9 @@ describe("Hub", () => {
     });
 
     test("only returns online participants", async () => {
-      const { room } = await createRoom("Test Room");
+      const {
+        data: { room },
+      } = await createRoom("Test Room");
       await joinRoom(room.code, {
         id: "participant-1",
         nickname: "test-user",
@@ -849,7 +899,9 @@ describe("Hub", () => {
       const participantServer = createMockParticipantServer("responses");
 
       try {
-        const { room } = await createRoom("Responses Room");
+        const {
+          data: { room },
+        } = await createRoom("Responses Room");
         await joinRoom(room.code, {
           id: "participant-native",
           nickname: "native-server",
@@ -918,38 +970,43 @@ describe("Hub", () => {
       });
 
       try {
-        const { room } = await createRoom("Authenticated Responses Room");
+        const {
+          data: { room },
+        } = await createRoom("Authenticated Responses Room");
         const joined = JoinResponseSchema.parse(
           await (
-            await fetch(`${baseUrl}/rooms/${room.code}/join`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                id: "participant-auth",
-                nickname: "auth-server",
-                model: "llama3",
-                endpoint: participantServer.url,
-                authHeaders: {
-                  Authorization: "Bearer secret-token",
-                },
-                capabilities: {
-                  openResponses: "supported",
-                  chatCompletions: "supported",
-                },
-              }),
-            })
+            await fetch(
+              `${baseUrl}/v1/rooms/${room.code}/participants/participant-auth`,
+              {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  id: "participant-auth",
+                  nickname: "auth-server",
+                  model: "llama3",
+                  endpoint: participantServer.url,
+                  authHeaders: {
+                    Authorization: "Bearer secret-token",
+                  },
+                  capabilities: {
+                    openResponses: "supported",
+                    chatCompletions: "supported",
+                  },
+                }),
+              }
+            )
           ).json()
         );
 
-        expect(joined.participant).not.toHaveProperty("authHeaders");
+        expect(joined.data.participant).not.toHaveProperty("authHeaders");
 
         const participantsResponse = await fetch(
-          `${baseUrl}/rooms/${room.code}/participants`
+          `${baseUrl}/v1/rooms/${room.code}/participants`
         );
         const participants = ParticipantsResponseSchema.parse(
           await participantsResponse.json()
         );
-        expect(participants.participants[0]).not.toHaveProperty("authHeaders");
+        expect(participants.data[0]).not.toHaveProperty("authHeaders");
 
         const createResponse = await fetch(
           `${baseUrl}/rooms/${room.code}/v1/responses`,
@@ -976,7 +1033,9 @@ describe("Hub", () => {
       const participantServer = createMockParticipantServer("chat-only");
 
       try {
-        const { room } = await createRoom("Fallback Room");
+        const {
+          data: { room },
+        } = await createRoom("Fallback Room");
         await joinRoom(room.code, {
           id: "participant-fallback",
           nickname: "fallback-server",
@@ -1009,7 +1068,7 @@ describe("Hub", () => {
         const retrieveResponse = await fetch(
           `${baseUrl}/rooms/${room.code}/v1/responses/${created.id}`
         );
-        const retrieveError = ErrorResponseSchema.parse(
+        const retrieveError = LegacyErrorResponseSchema.parse(
           await retrieveResponse.json()
         );
 
@@ -1024,7 +1083,9 @@ describe("Hub", () => {
       const participantServer = createMockParticipantServer("chat-only");
 
       try {
-        const { room } = await createRoom("Streaming Fallback Room");
+        const {
+          data: { room },
+        } = await createRoom("Streaming Fallback Room");
         await joinRoom(room.code, {
           id: "participant-stream",
           nickname: "stream-server",
@@ -1063,7 +1124,9 @@ describe("Hub", () => {
       const participantServer = createMockParticipantServer("responses");
 
       try {
-        const { room } = await createRoom("Merged Responses Room", {
+        const {
+          data: { room },
+        } = await createRoom("Merged Responses Room", {
           instructions: "Room instructions",
           temperature: 0.2,
           max_tokens: 128,
@@ -1115,7 +1178,9 @@ describe("Hub", () => {
       const participantServer = createMockParticipantServer("chat-only");
 
       try {
-        const { room } = await createRoom("Merged Chat Room", {
+        const {
+          data: { room },
+        } = await createRoom("Merged Chat Room", {
           instructions: "Room instructions",
           temperature: 0.2,
         });
@@ -1171,7 +1236,7 @@ describe("Hub", () => {
 
   describe("OPTIONS (CORS)", () => {
     test("returns CORS headers", async () => {
-      const res = await fetch(`${baseUrl}/rooms`, { method: "OPTIONS" });
+      const res = await fetch(`${baseUrl}/v1/rooms`, { method: "OPTIONS" });
 
       expect(res.status).toBe(204);
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -1505,6 +1505,86 @@ function createStreamingHeaders(): Record<string, string> {
   };
 }
 
+function broadcastLlmComplete(
+  code: string,
+  participant: ParticipantInfoInternal
+): void {
+  SSE.broadcast(
+    "llm.complete",
+    {
+      participantId: participant.id,
+    },
+    code
+  );
+}
+
+function broadcastLlmError(
+  code: string,
+  participant: ParticipantInfoInternal,
+  model: string,
+  proxyError: unknown
+): void {
+  SSE.broadcast(
+    "llm.error",
+    {
+      participantId: participant.id,
+      nickname: participant.nickname,
+      endpoint: participant.endpoint,
+      model,
+      error: String(proxyError),
+    },
+    code
+  );
+}
+
+function wrapProxyLifecycleStream(
+  response: Response,
+  params: {
+    code: string;
+    model: string;
+    participant: ParticipantInfoInternal;
+  }
+): Response {
+  if (!response.body) {
+    broadcastLlmComplete(params.code, params.participant);
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          broadcastLlmComplete(params.code, params.participant);
+          controller.close();
+          return;
+        }
+
+        if (value) {
+          controller.enqueue(value);
+        }
+      } catch (streamError) {
+        broadcastLlmError(
+          params.code,
+          params.participant,
+          params.model,
+          streamError
+        );
+        controller.error(streamError);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
 async function forwardNativeResponsesCreate(
   response: Response,
   isStreaming: boolean | undefined,
@@ -1785,6 +1865,15 @@ async function proxyResponsesCreate(
       });
 
       if (response !== ADAPTER_SKIP) {
+        if (request.stream) {
+          return wrapProxyLifecycleStream(response, {
+            code,
+            model: body.model,
+            participant,
+          });
+        }
+
+        broadcastLlmComplete(code, participant);
         return response;
       }
     }
@@ -1794,17 +1883,7 @@ async function proxyResponsesCreate(
       501
     );
   } catch (proxyError) {
-    SSE.broadcast(
-      "llm.error",
-      {
-        participantId: participant.id,
-        nickname: participant.nickname,
-        endpoint: participant.endpoint,
-        model: body.model,
-        error: String(proxyError),
-      },
-      code
-    );
+    broadcastLlmError(code, participant, body.model, proxyError);
     console.error("[gambi] responses proxy failed", {
       participantId: participant.id,
       nickname: participant.nickname,
@@ -1838,23 +1917,24 @@ async function proxyChatCompletions(
   );
 
   try {
-    return await chatCompletionsAdapter.create({
+    const response = await chatCompletionsAdapter.create({
       authHeaders,
       participant,
       request,
     });
-  } catch (proxyError) {
-    SSE.broadcast(
-      "llm.error",
-      {
-        participantId: participant.id,
-        nickname: participant.nickname,
-        endpoint: participant.endpoint,
+
+    if (request.stream) {
+      return wrapProxyLifecycleStream(response, {
+        code,
         model: body.model,
-        error: String(proxyError),
-      },
-      code
-    );
+        participant,
+      });
+    }
+
+    broadcastLlmComplete(code, participant);
+    return response;
+  } catch (proxyError) {
+    broadcastLlmError(code, participant, body.model, proxyError);
     console.error("[gambi] chat proxy failed", {
       participantId: participant.id,
       nickname: participant.nickname,

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -28,8 +28,8 @@ import {
   type ParticipantAuthHeaders,
   type ParticipantInfo,
   type ParticipantInfoInternal,
-  ParticipantSummary,
   ParticipantRegistration,
+  ParticipantSummary,
   RoomSummary,
   RuntimeConfig,
 } from "./types.ts";
@@ -51,6 +51,8 @@ export interface Hub {
 // Top-level regex for route matching
 const ROOM_PATH_REGEX = /^\/rooms\/([^/]+)/;
 const MANAGEMENT_ROOM_PATH_REGEX = /^\/v1\/rooms\/([^/]+)/;
+const MANAGEMENT_PARTICIPANT_PATH_REGEX =
+  /^\/v1\/rooms\/([^/]+)\/participants\/([^/]+)(?:\/heartbeat)?$/;
 const RESPONSES_PATH_REGEX =
   /^\/rooms\/([^/]+)\/v1\/responses\/([^/]+)(?:\/(cancel|input_items))?$/;
 const TRAILING_SLASH_REGEX = /\/$/;
@@ -394,11 +396,25 @@ function applyChatCompletionsDefaults(
 
 // Route handlers
 async function createRoom(req: Request, requestId: string): Promise<Response> {
-  const body = (await req.json()) as {
+  let body: {
     defaults?: unknown;
     name?: string;
     password?: string;
   };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch (error) {
+    return managementError(
+      requestId,
+      "INVALID_REQUEST",
+      "Invalid JSON body.",
+      "Provide a valid JSON object and retry.",
+      400,
+      {
+        cause: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
   if (!body.name) {
     return managementError(
       requestId,
@@ -477,7 +493,21 @@ async function upsertParticipant(
     );
   }
 
-  const bodyInput = (await req.json()) as Record<string, unknown>;
+  let bodyInput: Record<string, unknown>;
+  try {
+    bodyInput = (await req.json()) as Record<string, unknown>;
+  } catch (error) {
+    return managementError(
+      requestId,
+      "INVALID_REQUEST",
+      "Invalid JSON body.",
+      "Provide a valid JSON object and retry.",
+      400,
+      {
+        cause: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
   bodyInput.id = participantId;
   if (!(bodyInput.nickname && bodyInput.model && bodyInput.endpoint)) {
     return managementError(
@@ -546,7 +576,11 @@ async function upsertParticipant(
     updatedAt: now,
   };
 
-  const result = Room.upsertParticipant(room.id, participant, body.authHeaders ?? {});
+  const result = Room.upsertParticipant(
+    room.id,
+    participant,
+    body.authHeaders ?? {}
+  );
   if (!result) {
     return managementError(
       requestId,
@@ -1902,18 +1936,17 @@ async function proxyStoredResponse(
   });
 }
 
-function sseEvents(code: string): Response {
+function sseEvents(
+  code: string,
+  requestId: string = crypto.randomUUID()
+): Response {
   const room = Room.getByCode(code);
   if (!room) {
-    return json(
-      {
-        error: {
-          code: "ROOM_NOT_FOUND",
-          message: "Room not found.",
-          hint: "Run 'gambi room list' to inspect available rooms.",
-        },
-        meta: { requestId: crypto.randomUUID() },
-      },
+    return managementError(
+      requestId,
+      "ROOM_NOT_FOUND",
+      "Room not found.",
+      "Run 'gambi room list' to inspect available rooms.",
       404
     );
   }
@@ -1972,7 +2005,7 @@ function handleRoomRoute(
   method: string,
   path: string,
   code: string,
-  requesterIp: string | null
+  _requesterIp: string | null
 ): Promise<Response> | Response | null {
   if (path === `/rooms/${code}/v1/models` && method === "GET") {
     return listModels(code);
@@ -2010,15 +2043,19 @@ function handleManagementRoomRoute(
     return getParticipants(code, requestId);
   }
 
-  const participantMatch = path.match(
-    /^\/v1\/rooms\/([^/]+)\/participants\/([^/]+)(?:\/heartbeat)?$/
-  );
+  const participantMatch = path.match(MANAGEMENT_PARTICIPANT_PATH_REGEX);
   if (participantMatch?.[1] === code && participantMatch[2]) {
     const participantId = participantMatch[2];
     const isHeartbeat = path.endsWith("/heartbeat");
 
     if (method === "PUT" && !isHeartbeat) {
-      return upsertParticipant(req, code, participantId, requesterIp, requestId);
+      return upsertParticipant(
+        req,
+        code,
+        participantId,
+        requesterIp,
+        requestId
+      );
     }
 
     if (method === "DELETE" && !isHeartbeat) {
@@ -2031,7 +2068,7 @@ function handleManagementRoomRoute(
   }
 
   if (path === `/v1/rooms/${code}/events` && method === "GET") {
-    return sseEvents(code);
+    return sseEvents(code, requestId);
   }
 
   return null;

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -21,11 +21,16 @@ import {
 import { Room } from "./room.ts";
 import { SSE } from "./sse.ts";
 import {
+  type ApiErrorCode,
+  type ApiMeta,
   HEALTH_CHECK_INTERVAL,
+  type HeartbeatResult,
   type ParticipantAuthHeaders,
   type ParticipantInfo,
   type ParticipantInfoInternal,
+  ParticipantSummary,
   ParticipantRegistration,
+  RoomSummary,
   RuntimeConfig,
 } from "./types.ts";
 
@@ -45,7 +50,7 @@ export interface Hub {
 
 // Top-level regex for route matching
 const ROOM_PATH_REGEX = /^\/rooms\/([^/]+)/;
-const LEAVE_PATH_REGEX = /^\/rooms\/[^/]+\/leave\/[^/]+$/;
+const MANAGEMENT_ROOM_PATH_REGEX = /^\/v1\/rooms\/([^/]+)/;
 const RESPONSES_PATH_REGEX =
   /^\/rooms\/([^/]+)\/v1\/responses\/([^/]+)(?:\/(cancel|input_items))?$/;
 const TRAILING_SLASH_REGEX = /\/$/;
@@ -98,12 +103,48 @@ function error(message: string, status = 400): Response {
   return json({ error: message }, status);
 }
 
+function managementJson(
+  data: unknown,
+  requestId: string,
+  status = 200
+): Response {
+  return json(
+    {
+      data,
+      meta: { requestId } satisfies ApiMeta,
+    },
+    status
+  );
+}
+
+function managementError(
+  requestId: string,
+  code: ApiErrorCode,
+  message: string,
+  hint?: string,
+  status = 400,
+  details?: unknown
+): Response {
+  return json(
+    {
+      error: {
+        code,
+        message,
+        hint,
+        details,
+      },
+      meta: { requestId } satisfies ApiMeta,
+    },
+    status
+  );
+}
+
 function corsHeaders(): Response {
   return new Response(null, {
     status: 204,
     headers: {
       "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type, Authorization",
     },
   });
@@ -352,21 +393,33 @@ function applyChatCompletionsDefaults(
 }
 
 // Route handlers
-async function createRoom(req: Request): Promise<Response> {
+async function createRoom(req: Request, requestId: string): Promise<Response> {
   const body = (await req.json()) as {
     defaults?: unknown;
     name?: string;
     password?: string;
   };
   if (!body.name) {
-    return error("Name is required");
+    return managementError(
+      requestId,
+      "INVALID_REQUEST",
+      "Name is required",
+      "Provide a room name via the 'name' field."
+    );
   }
 
   let defaults: RuntimeConfig | undefined;
   if (body.defaults !== undefined) {
     const parsedDefaults = RuntimeConfig.safeParse(body.defaults);
     if (!parsedDefaults.success) {
-      return error(`Invalid room defaults: ${parsedDefaults.error.message}`);
+      return managementError(
+        requestId,
+        "INVALID_REQUEST",
+        "Invalid room defaults.",
+        "Check the runtime config payload and retry.",
+        400,
+        parsedDefaults.error.flatten()
+      );
     }
     defaults = parsedDefaults.data;
   }
@@ -375,43 +428,77 @@ async function createRoom(req: Request): Promise<Response> {
   const room = await Room.create(body.name, hostId, body.password, defaults);
 
   // Strip password hash from public responses to prevent offline brute-force attacks
-  const publicRoom = Room.toPublic(room);
+  const summary = RoomSummary.parse({
+    ...Room.toPublic(room),
+    participantCount: 0,
+  });
 
-  SSE.broadcast("room:created", publicRoom);
+  SSE.broadcast("room.created", summary, room.code);
 
-  return json({ room: publicRoom, hostId }, 201);
+  return managementJson({ room: summary, hostId }, requestId, 201);
 }
 
-function listRooms(): Response {
-  return json({ rooms: Room.listWithParticipantCount() });
+function listRooms(requestId: string): Response {
+  return managementJson(Room.listWithParticipantCount(), requestId);
 }
 
-async function joinRoom(
+function getRoomSummary(code: string, requestId: string): Response {
+  const room = Room.listWithParticipantCount().find(
+    (candidate) => candidate.code === code.toUpperCase()
+  );
+  if (!room) {
+    return managementError(
+      requestId,
+      "ROOM_NOT_FOUND",
+      "Room not found.",
+      "Run 'gambi room list' to inspect available rooms.",
+      404
+    );
+  }
+
+  return managementJson(room, requestId);
+}
+
+async function upsertParticipant(
   req: Request,
   code: string,
-  requesterIp: string | null
+  participantId: string,
+  requesterIp: string | null,
+  requestId: string
 ): Promise<Response> {
   const room = Room.getByCode(code);
   if (!room) {
-    return error("Room not found", 404);
+    return managementError(
+      requestId,
+      "ROOM_NOT_FOUND",
+      "Room not found.",
+      "Run 'gambi room list' to inspect available rooms.",
+      404
+    );
   }
 
   const bodyInput = (await req.json()) as Record<string, unknown>;
-  if (
-    !(
-      bodyInput.id &&
-      bodyInput.nickname &&
-      bodyInput.model &&
-      bodyInput.endpoint
-    )
-  ) {
-    return error("Missing required fields: id, nickname, model, endpoint");
+  bodyInput.id = participantId;
+  if (!(bodyInput.nickname && bodyInput.model && bodyInput.endpoint)) {
+    return managementError(
+      requestId,
+      "INVALID_REQUEST",
+      "Missing required fields.",
+      "Provide nickname, model, and endpoint.",
+      400,
+      { required: ["nickname", "model", "endpoint"] }
+    );
   }
 
   const parsedBody = ParticipantRegistration.safeParse(bodyInput);
   if (!parsedBody.success) {
-    return error(
-      `Invalid participant registration: ${parsedBody.error.message}`
+    return managementError(
+      requestId,
+      "INVALID_REQUEST",
+      "Invalid participant registration.",
+      "Check the participant payload and retry.",
+      400,
+      parsedBody.error.flatten()
     );
   }
 
@@ -421,7 +508,12 @@ async function joinRoom(
     body.endpoint
   );
   if (remoteLoopbackJoinError) {
-    return error(remoteLoopbackJoinError, 400);
+    return managementError(
+      requestId,
+      "LOOPBACK_ENDPOINT_FOR_REMOTE_HUB",
+      remoteLoopbackJoinError,
+      "Publish a network-reachable endpoint, for example via '--network-endpoint'."
+    );
   }
 
   // Validate password if room is protected
@@ -430,7 +522,13 @@ async function joinRoom(
     body.password ?? ""
   );
   if (!isPasswordValid) {
-    return error("Invalid password", 401);
+    return managementError(
+      requestId,
+      "INVALID_PASSWORD",
+      "Invalid password.",
+      "Provide the correct room password and retry.",
+      401
+    );
   }
 
   const now = Date.now();
@@ -445,59 +543,118 @@ async function joinRoom(
     status: "online",
     joinedAt: now,
     lastSeen: now,
+    updatedAt: now,
   };
 
-  Room.addParticipant(room.id, participant, body.authHeaders ?? {});
+  const result = Room.upsertParticipant(room.id, participant, body.authHeaders ?? {});
+  if (!result) {
+    return managementError(
+      requestId,
+      "INTERNAL_ERROR",
+      "Failed to register participant.",
+      "Retry the operation."
+    );
+  }
 
-  const publicParticipant = Participant.toPublicInfo(participant);
+  const publicParticipant = ParticipantSummary.parse(
+    Participant.toPublicInfo(result.participant)
+  );
 
-  SSE.broadcast("participant:joined", publicParticipant, code);
+  SSE.broadcast(
+    result.created ? "participant.joined" : "participant.updated",
+    publicParticipant,
+    code
+  );
 
-  return json({ participant: publicParticipant, roomId: room.id }, 201);
+  return managementJson(
+    { participant: publicParticipant, roomId: room.id },
+    requestId,
+    result.created ? 201 : 200
+  );
 }
 
-function leaveRoom(code: string, participantId: string): Response {
+function leaveRoom(
+  code: string,
+  participantId: string,
+  requestId: string
+): Response {
   const room = Room.getByCode(code);
   if (!room) {
-    return error("Room not found", 404);
+    return managementError(
+      requestId,
+      "ROOM_NOT_FOUND",
+      "Room not found.",
+      "Run 'gambi room list' to inspect available rooms.",
+      404
+    );
   }
 
   const removed = Room.removeParticipant(room.id, participantId);
   if (!removed) {
-    return error("Participant not found", 404);
+    return managementError(
+      requestId,
+      "PARTICIPANT_NOT_FOUND",
+      "Participant not found.",
+      "Check the participant id and retry.",
+      404
+    );
   }
 
-  SSE.broadcast("participant:left", { participantId }, code);
+  SSE.broadcast("participant.left", { participantId }, code);
 
-  return json({ success: true });
+  return managementJson({ success: true }, requestId);
 }
 
-async function healthCheck(req: Request, code: string): Promise<Response> {
+function heartbeatParticipant(
+  code: string,
+  participantId: string,
+  requestId: string
+): Response {
   const room = Room.getByCode(code);
   if (!room) {
-    return error("Room not found", 404);
+    return managementError(
+      requestId,
+      "ROOM_NOT_FOUND",
+      "Room not found.",
+      "Run 'gambi room list' to inspect available rooms.",
+      404
+    );
   }
 
-  const body = (await req.json()) as { id: string };
-  if (!body.id) {
-    return error("Participant ID is required");
-  }
-
-  const updated = Room.updateLastSeen(room.id, body.id);
+  const updated = Room.updateLastSeen(room.id, participantId);
   if (!updated) {
-    return error("Participant not found", 404);
+    return managementError(
+      requestId,
+      "PARTICIPANT_NOT_FOUND",
+      "Participant not found.",
+      "Check the participant id and retry.",
+      404
+    );
   }
 
-  return json({ success: true });
+  const participant = Room.getParticipant(room.id, participantId);
+  const heartbeat: HeartbeatResult = {
+    success: true,
+    status: participant?.status ?? "online",
+    lastSeen: participant?.lastSeen ?? Date.now(),
+  };
+
+  return managementJson(heartbeat, requestId);
 }
 
-function getParticipants(code: string): Response {
+function getParticipants(code: string, requestId: string): Response {
   const room = Room.getByCode(code);
   if (!room) {
-    return error("Room not found", 404);
+    return managementError(
+      requestId,
+      "ROOM_NOT_FOUND",
+      "Room not found.",
+      "Run 'gambi room list' to inspect available rooms.",
+      404
+    );
   }
 
-  return json({ participants: Room.getParticipants(room.id) });
+  return managementJson(Room.getParticipants(room.id), requestId);
 }
 
 function listModels(code: string): Response {
@@ -1571,7 +1728,7 @@ async function proxyResponsesCreate(
   };
 
   SSE.broadcast(
-    "llm:request",
+    "llm.request",
     { participantId: participant.id, model: body.model },
     code
   );
@@ -1604,7 +1761,7 @@ async function proxyResponsesCreate(
     );
   } catch (proxyError) {
     SSE.broadcast(
-      "llm:error",
+      "llm.error",
       {
         participantId: participant.id,
         nickname: participant.nickname,
@@ -1641,7 +1798,7 @@ async function proxyChatCompletions(
   );
 
   SSE.broadcast(
-    "llm:request",
+    "llm.request",
     { participantId: participant.id, model: body.model },
     code
   );
@@ -1654,7 +1811,7 @@ async function proxyChatCompletions(
     });
   } catch (proxyError) {
     SSE.broadcast(
-      "llm:error",
+      "llm.error",
       {
         participantId: participant.id,
         nickname: participant.nickname,
@@ -1748,15 +1905,25 @@ async function proxyStoredResponse(
 function sseEvents(code: string): Response {
   const room = Room.getByCode(code);
   if (!room) {
-    return error("Room not found", 404);
+    return json(
+      {
+        error: {
+          code: "ROOM_NOT_FOUND",
+          message: "Room not found.",
+          hint: "Run 'gambi room list' to inspect available rooms.",
+        },
+        meta: { requestId: crypto.randomUUID() },
+      },
+      404
+    );
   }
 
   const clientId = crypto.randomUUID();
   return SSE.createResponse(clientId, code);
 }
 
-function hubHealth(): Response {
-  return json({ status: "ok", timestamp: Date.now() });
+function hubHealth(requestId: string): Response {
+  return managementJson({ status: "ok", timestamp: Date.now() }, requestId);
 }
 
 function handleResponsesRoute(
@@ -1807,25 +1974,6 @@ function handleRoomRoute(
   code: string,
   requesterIp: string | null
 ): Promise<Response> | Response | null {
-  if (path === `/rooms/${code}/join` && method === "POST") {
-    return joinRoom(req, code, requesterIp);
-  }
-
-  if (LEAVE_PATH_REGEX.test(path) && method === "DELETE") {
-    const participantId = path.split("/").pop();
-    if (participantId) {
-      return leaveRoom(code, participantId);
-    }
-  }
-
-  if (path === `/rooms/${code}/health` && method === "POST") {
-    return healthCheck(req, code);
-  }
-
-  if (path === `/rooms/${code}/participants` && method === "GET") {
-    return getParticipants(code);
-  }
-
   if (path === `/rooms/${code}/v1/models` && method === "GET") {
     return listModels(code);
   }
@@ -1840,6 +1988,49 @@ function handleRoomRoute(
   }
 
   if (path === `/rooms/${code}/events` && method === "GET") {
+    return sseEvents(code);
+  }
+
+  return null;
+}
+
+function handleManagementRoomRoute(
+  req: Request,
+  method: string,
+  path: string,
+  code: string,
+  requesterIp: string | null,
+  requestId: string
+): Promise<Response> | Response | null {
+  if (path === `/v1/rooms/${code}` && method === "GET") {
+    return getRoomSummary(code, requestId);
+  }
+
+  if (path === `/v1/rooms/${code}/participants` && method === "GET") {
+    return getParticipants(code, requestId);
+  }
+
+  const participantMatch = path.match(
+    /^\/v1\/rooms\/([^/]+)\/participants\/([^/]+)(?:\/heartbeat)?$/
+  );
+  if (participantMatch?.[1] === code && participantMatch[2]) {
+    const participantId = participantMatch[2];
+    const isHeartbeat = path.endsWith("/heartbeat");
+
+    if (method === "PUT" && !isHeartbeat) {
+      return upsertParticipant(req, code, participantId, requesterIp, requestId);
+    }
+
+    if (method === "DELETE" && !isHeartbeat) {
+      return leaveRoom(code, participantId, requestId);
+    }
+
+    if (method === "POST" && isHeartbeat) {
+      return heartbeatParticipant(code, participantId, requestId);
+    }
+  }
+
+  if (path === `/v1/rooms/${code}/events` && method === "GET") {
     return sseEvents(code);
   }
 
@@ -1866,7 +2057,7 @@ export function createHub(options: HubOptions = {}): Hub {
     for (const { roomId, participantId } of stale) {
       const room = Room.get(roomId);
       if (room) {
-        SSE.broadcast("participant:offline", { participantId }, room.code);
+        SSE.broadcast("participant.offline", { participantId }, room.code);
       }
     }
   }, HEALTH_CHECK_INTERVAL);
@@ -1878,20 +2069,37 @@ export function createHub(options: HubOptions = {}): Hub {
       const url = new URL(req.url);
       const method = req.method;
       const path = url.pathname;
+      const requestId = crypto.randomUUID();
 
       if (method === "OPTIONS") {
         return corsHeaders();
       }
 
-      if (path === "/health" && method === "GET") {
-        return hubHealth();
+      if (path === "/v1/health" && method === "GET") {
+        return hubHealth(requestId);
       }
 
-      if (path === "/rooms" && method === "POST") {
-        return createRoom(req);
+      if (path === "/v1/rooms" && method === "POST") {
+        return createRoom(req, requestId);
       }
-      if (path === "/rooms" && method === "GET") {
-        return listRooms();
+      if (path === "/v1/rooms" && method === "GET") {
+        return listRooms(requestId);
+      }
+
+      const managementRoomMatch = path.match(MANAGEMENT_ROOM_PATH_REGEX);
+      if (managementRoomMatch?.[1]) {
+        const requesterIp = getRequesterIp(req, server);
+        const result = handleManagementRoomRoute(
+          req,
+          method,
+          path,
+          managementRoomMatch[1],
+          requesterIp,
+          requestId
+        );
+        if (result) {
+          return result;
+        }
       }
 
       const roomMatch = path.match(ROOM_PATH_REGEX);
@@ -1909,7 +2117,13 @@ export function createHub(options: HubOptions = {}): Hub {
         }
       }
 
-      return new Response("Not Found", { status: 404 });
+      return managementError(
+        requestId,
+        "INVALID_REQUEST",
+        "Route not found.",
+        "Check the requested path and HTTP method.",
+        404
+      );
     },
   });
 

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -459,9 +459,7 @@ function listRooms(requestId: string): Response {
 }
 
 function getRoomSummary(code: string, requestId: string): Response {
-  const room = Room.listWithParticipantCount().find(
-    (candidate) => candidate.code === code.toUpperCase()
-  );
+  const room = Room.getSummaryByCode(code);
   if (!room) {
     return managementError(
       requestId,

--- a/packages/core/src/participant.ts
+++ b/packages/core/src/participant.ts
@@ -33,6 +33,7 @@ function create(options: CreateParticipantOptions): ParticipantInfoInternal {
     status: "online",
     joinedAt: now,
     lastSeen: now,
+    updatedAt: now,
   };
 }
 

--- a/packages/core/src/room.test.ts
+++ b/packages/core/src/room.test.ts
@@ -21,6 +21,7 @@ function createMockParticipant(
     status: overrides.status ?? "online",
     joinedAt: overrides.joinedAt ?? now,
     lastSeen: overrides.lastSeen ?? now,
+    updatedAt: overrides.updatedAt ?? now,
   };
 }
 

--- a/packages/core/src/room.test.ts
+++ b/packages/core/src/room.test.ts
@@ -118,6 +118,23 @@ describe("Room", () => {
     });
   });
 
+  describe("getSummaryByCode", () => {
+    test("returns a single room summary without scanning all rooms", async () => {
+      const room = await Room.create("Test", "host");
+      Room.addParticipant(room.id, createMockParticipant());
+
+      const summary = Room.getSummaryByCode(room.code);
+
+      expect(summary).toBeDefined();
+      expect(summary?.code).toBe(room.code);
+      expect(summary?.participantCount).toBe(1);
+    });
+
+    test("returns undefined for non-existent codes", () => {
+      expect(Room.getSummaryByCode("XXXXXX")).toBeUndefined();
+    });
+  });
+
   describe("remove", () => {
     test("removes existing room", async () => {
       const room = await Room.create("Test", "host");

--- a/packages/core/src/room.test.ts
+++ b/packages/core/src/room.test.ts
@@ -199,6 +199,19 @@ describe("Room", () => {
     test("getParticipants returns empty array for non-existent room", () => {
       expect(Room.getParticipants("non-existent")).toEqual([]);
     });
+
+    test("upsertParticipant preserves an explicit joinedAt value of zero", async () => {
+      const room = await Room.create("Test", "host");
+      const participant = createMockParticipant({
+        id: "participant-zero",
+        joinedAt: 0,
+      });
+
+      const result = Room.upsertParticipant(room.id, participant);
+
+      expect(result?.created).toBe(true);
+      expect(result?.participant.joinedAt).toBe(0);
+    });
   });
 
   describe("updateParticipantStatus", () => {

--- a/packages/core/src/room.ts
+++ b/packages/core/src/room.ts
@@ -152,7 +152,7 @@ function upsertParticipant(
       }
     : {
         ...participant,
-        joinedAt: participant.joinedAt || now,
+        joinedAt: participant.joinedAt ?? now,
         lastSeen: now,
         updatedAt: now,
         status: "online",

--- a/packages/core/src/room.ts
+++ b/packages/core/src/room.ts
@@ -7,6 +7,7 @@ import {
   type ParticipantInfoInternal,
   type RoomInfo,
   type RoomInfoPublic,
+  type RoomSummary,
   type RuntimeConfig,
 } from "./types.ts";
 
@@ -29,6 +30,14 @@ function toPublic(room: RoomInfo): RoomInfoPublic {
   return {
     ...publicRoom,
     defaults: defaults ? Participant.toPublicConfig(defaults) : undefined,
+    passwordProtected: !!passwordHash,
+  };
+}
+
+function toSummary(room: RoomState): RoomSummary {
+  return {
+    ...toPublic(room.info),
+    participantCount: room.participants.size,
   };
 }
 
@@ -89,10 +98,7 @@ function list(): RoomInfoPublic[] {
 function listWithParticipantCount(): (RoomInfoPublic & {
   participantCount: number;
 })[] {
-  return Array.from(rooms.values()).map((r) => ({
-    ...toPublic(r.info),
-    participantCount: r.participants.size,
-  }));
+  return Array.from(rooms.values()).map((room) => toSummary(room));
 }
 
 function remove(id: string): boolean {
@@ -121,6 +127,46 @@ function addParticipant(
     authHeaders,
   });
   return true;
+}
+
+function upsertParticipant(
+  roomId: string,
+  participant: ParticipantInfoInternal,
+  authHeaders: ParticipantAuthHeaders = {}
+): { created: boolean; participant: ParticipantInfoInternal } | null {
+  const room = rooms.get(roomId);
+  if (!room) {
+    return null;
+  }
+
+  const existing = room.participants.get(participant.id)?.info;
+  const now = Date.now();
+  const nextParticipant: ParticipantInfoInternal = existing
+    ? {
+        ...existing,
+        ...participant,
+        joinedAt: existing.joinedAt,
+        lastSeen: now,
+        updatedAt: now,
+        status: "online",
+      }
+    : {
+        ...participant,
+        joinedAt: participant.joinedAt || now,
+        lastSeen: now,
+        updatedAt: now,
+        status: "online",
+      };
+
+  room.participants.set(nextParticipant.id, {
+    info: nextParticipant,
+    authHeaders,
+  });
+
+  return {
+    created: !existing,
+    participant: nextParticipant,
+  };
 }
 
 function removeParticipant(roomId: string, participantId: string): boolean {
@@ -177,6 +223,7 @@ function updateLastSeen(roomId: string, participantId: string): boolean {
   }
 
   participant.lastSeen = Date.now();
+  participant.updatedAt = participant.lastSeen;
   participant.status = "online";
   return true;
 }
@@ -268,8 +315,10 @@ export const Room = {
   getByCode,
   list,
   listWithParticipantCount,
+  toSummary,
   remove,
   addParticipant,
+  upsertParticipant,
   removeParticipant,
   getParticipants,
   getParticipant,

--- a/packages/core/src/room.ts
+++ b/packages/core/src/room.ts
@@ -101,6 +101,12 @@ function listWithParticipantCount(): (RoomInfoPublic & {
   return Array.from(rooms.values()).map((room) => toSummary(room));
 }
 
+function getSummaryByCode(code: string): RoomSummary | undefined {
+  const id = codeToRoomId.get(code.toUpperCase());
+  const room = id ? rooms.get(id) : undefined;
+  return room ? toSummary(room) : undefined;
+}
+
 function remove(id: string): boolean {
   const room = rooms.get(id);
   if (!room) {
@@ -313,6 +319,7 @@ export const Room = {
   create,
   get,
   getByCode,
+  getSummaryByCode,
   list,
   listWithParticipantCount,
   toSummary,

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -1,6 +1,7 @@
 /**
  * Server-Sent Events helper for broadcasting events to TUI clients
  */
+import type { RoomEvent, RoomEventType } from "./types.ts";
 
 export interface SSEClient {
   id: string;
@@ -23,8 +24,14 @@ export function createSSEResponse(
       clients.set(clientId, { id: clientId, controller, roomCode });
 
       // Send initial connection event
+      const connectedEvent: RoomEvent = {
+        type: "connected",
+        timestamp: Date.now(),
+        roomCode,
+        data: { clientId },
+      };
       const data = encoder.encode(
-        `event: connected\ndata: ${JSON.stringify({ clientId })}\n\n`
+        `event: connected\ndata: ${JSON.stringify(connectedEvent)}\n\n`
       );
       controller.enqueue(data);
     },
@@ -47,12 +54,18 @@ export function createSSEResponse(
  * Broadcast an event to all connected clients
  */
 export function broadcast(
-  event: string,
+  event: RoomEventType,
   data: unknown,
   roomCode?: string
 ): void {
+  const payload: RoomEvent = {
+    type: event,
+    timestamp: Date.now(),
+    roomCode,
+    data,
+  };
   const message = encoder.encode(
-    `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+    `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`
   );
 
   for (const client of clients.values()) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,6 +101,7 @@ export const ParticipantInfoInternal = z.object({
   status: ParticipantStatus,
   joinedAt: z.number(),
   lastSeen: z.number(), // Timestamp of last health check
+  updatedAt: z.number(),
 });
 
 export type ParticipantInfoInternal = z.infer<typeof ParticipantInfoInternal>;
@@ -119,6 +120,7 @@ export const ParticipantInfo = z.object({
   status: ParticipantStatus,
   joinedAt: z.number(),
   lastSeen: z.number(),
+  updatedAt: z.number(),
 });
 
 export type ParticipantInfo = z.infer<typeof ParticipantInfo>;
@@ -156,6 +158,7 @@ export const RoomInfoPublic = z.object({
   hostId: z.string(),
   createdAt: z.number(),
   defaults: RuntimeConfigPublic.optional(),
+  passwordProtected: z.boolean().default(false),
 });
 
 // Type aliases
@@ -186,3 +189,86 @@ export const HubConfig = z.object({
 });
 
 export type HubConfig = z.infer<typeof HubConfig>;
+
+export const ApiMeta = z.object({
+  requestId: z.string(),
+});
+
+export type ApiMeta = z.infer<typeof ApiMeta>;
+
+export const ApiErrorCode = z.enum([
+  "ROOM_NOT_FOUND",
+  "PARTICIPANT_NOT_FOUND",
+  "INVALID_REQUEST",
+  "INVALID_PASSWORD",
+  "ENDPOINT_NOT_REACHABLE",
+  "LOOPBACK_ENDPOINT_FOR_REMOTE_HUB",
+  "PARTICIPANT_CONFLICT",
+  "MODEL_NOT_FOUND",
+  "INTERNAL_ERROR",
+]);
+
+export type ApiErrorCode = z.infer<typeof ApiErrorCode>;
+
+export const ApiErrorShape = z.object({
+  code: ApiErrorCode,
+  message: z.string(),
+  hint: z.string().optional(),
+  details: z.unknown().optional(),
+});
+
+export type ApiErrorShape = z.infer<typeof ApiErrorShape>;
+
+export const ApiErrorResponse = z.object({
+  error: ApiErrorShape,
+  meta: ApiMeta,
+});
+
+export type ApiErrorResponse = z.infer<typeof ApiErrorResponse>;
+
+export function createApiSuccessSchema<T extends z.ZodType>(data: T) {
+  return z.object({
+    data,
+    meta: ApiMeta,
+  });
+}
+
+export const RoomSummary = RoomInfoPublic.extend({
+  participantCount: z.number().int().nonnegative(),
+});
+
+export type RoomSummary = z.infer<typeof RoomSummary>;
+
+export const ParticipantSummary = ParticipantInfo;
+
+export type ParticipantSummary = z.infer<typeof ParticipantSummary>;
+
+export const HeartbeatResult = z.object({
+  success: z.literal(true),
+  status: ParticipantStatus,
+  lastSeen: z.number(),
+});
+
+export type HeartbeatResult = z.infer<typeof HeartbeatResult>;
+
+export const RoomEventType = z.enum([
+  "connected",
+  "room.created",
+  "participant.joined",
+  "participant.updated",
+  "participant.left",
+  "participant.offline",
+  "llm.request",
+  "llm.error",
+]);
+
+export type RoomEventType = z.infer<typeof RoomEventType>;
+
+export const RoomEvent = z.object({
+  type: RoomEventType,
+  timestamp: z.number(),
+  roomCode: z.string().optional(),
+  data: z.unknown(),
+});
+
+export type RoomEvent = z.infer<typeof RoomEvent>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -259,6 +259,7 @@ export const RoomEventType = z.enum([
   "participant.left",
   "participant.offline",
   "llm.request",
+  "llm.complete",
   "llm.error",
 ]);
 

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { createHub, type Hub } from "@gambi/core/hub";
 import { Room } from "@gambi/core/room";
 import { ClientError, createClient } from "./client.ts";
@@ -27,278 +27,118 @@ describe("HTTP Client", () => {
 
   beforeAll(() => {
     hub = createHubWithRetry();
-    Room.clear();
     client = createClient({ hubUrl: hub.url });
   });
 
   afterAll(() => {
     hub.close();
   });
-  describe("create", () => {
-    test("creates a new room", async () => {
-      const { room, hostId } = await client.create("Test Room");
 
-      expect(room.name).toBe("Test Room");
-      expect(room.code).toHaveLength(6);
-      expect(hostId).toBeDefined();
-    });
-
-    test("throws ClientError on failure", async () => {
-      // Invalid request (empty name will fail validation)
-      await expect(
-        fetch(`${hub.url}/rooms`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        }).then((res) => res.json())
-      ).resolves.toHaveProperty("error");
-    });
-
-    test("supports room defaults via options object", async () => {
-      const { room } = await client.create("Configured Room", {
-        defaults: {
-          instructions: "Room instructions",
-          temperature: 0.4,
-        },
-      });
-
-      expect(room.defaults).toEqual({
-        hasInstructions: true,
-        temperature: 0.4,
-      });
-      expect(room.defaults).not.toHaveProperty("instructions");
-    });
+  beforeEach(() => {
+    Room.clear();
   });
 
-  describe("list", () => {
-    test("lists all rooms", async () => {
-      Room.clear();
-      await client.create("Room 1");
-      await client.create("Room 2");
+  test("creates and lists rooms through the namespaced client", async () => {
+    const created = await client.rooms.create({ name: "Test Room" });
+    const listed = await client.rooms.list();
 
-      const rooms = await client.list();
-
-      expect(rooms).toHaveLength(2);
-      expect(rooms[0].name).toBe("Room 1");
-      expect(rooms[1].name).toBe("Room 2");
-    });
-
-    test("returns empty array when no rooms", async () => {
-      Room.clear();
-      const rooms = await client.list();
-
-      expect(rooms).toEqual([]);
-    });
+    expect(created.data.room.name).toBe("Test Room");
+    expect(created.data.room.code).toHaveLength(6);
+    expect(listed.data).toHaveLength(1);
+    expect(listed.data[0]?.name).toBe("Test Room");
   });
 
-  describe("join", () => {
-    test("joins a room as a participant", async () => {
-      const { room } = await client.create("Test Room");
+  test("gets one room summary", async () => {
+    const created = await client.rooms.create({ name: "Lookup Room" });
+    const fetched = await client.rooms.get(created.data.room.code);
 
-      const { participant, roomId } = await client.join(room.code, {
-        id: "participant-1",
-        nickname: "Test Bot",
-        model: "llama3",
-        endpoint: "http://localhost:11434",
-      });
+    expect(fetched.data.code).toBe(created.data.room.code);
+    expect(fetched.data.passwordProtected).toBe(false);
+  });
 
-      expect(participant.id).toBe("participant-1");
-      expect(participant.nickname).toBe("Test Bot");
-      expect(roomId).toBe(room.id);
-    });
+  test("upserts participants and redacts runtime instructions publicly", async () => {
+    const created = await client.rooms.create({ name: "Workers" });
 
-    test("accepts auth headers without exposing them in the response", async () => {
-      const { room } = await client.create("Authenticated Room");
-
-      const { participant } = await client.join(room.code, {
-        id: "participant-2",
-        nickname: "Remote Bot",
-        model: "gpt-4o-mini",
-        endpoint: "https://api.example.com",
-        authHeaders: {
-          Authorization: "Bearer secret-token",
-        },
-      });
-
-      expect(participant.id).toBe("participant-2");
-      expect(participant).not.toHaveProperty("authHeaders");
-    });
-
-    test("redacts instructions in public participant responses", async () => {
-      const { room } = await client.create("Configured Participant Room");
-
-      const { participant } = await client.join(room.code, {
-        id: "participant-3",
-        nickname: "Configured Bot",
+    const joined = await client.participants.upsert(
+      created.data.room.code,
+      "worker-1",
+      {
+        nickname: "Worker 1",
         model: "llama3",
         endpoint: "http://localhost:11434",
         config: {
-          instructions: "Private instructions",
-          temperature: 0.6,
+          instructions: "Private",
+          temperature: 0.4,
         },
-      });
+      }
+    );
 
-      expect(participant.config).toEqual({
-        hasInstructions: true,
-        temperature: 0.6,
-      });
-      expect(participant.config).not.toHaveProperty("instructions");
+    expect(joined.data.participant.id).toBe("worker-1");
+    expect(joined.data.participant.config).toEqual({
+      hasInstructions: true,
+      temperature: 0.4,
     });
 
-    test("throws ClientError for non-existent room", async () => {
-      await expect(
-        client.join("XXXXXX", {
-          id: "participant-1",
-          nickname: "Test Bot",
-          model: "llama3",
-          endpoint: "http://localhost:11434",
-        })
-      ).rejects.toThrow(ClientError);
+    const listed = await client.participants.list(created.data.room.code);
+    expect(listed.data).toHaveLength(1);
+    expect(listed.data[0]?.config).toEqual({
+      hasInstructions: true,
+      temperature: 0.4,
     });
   });
 
-  describe("leave", () => {
-    test("removes participant from room", async () => {
-      const { room } = await client.create("Test Room");
-      await client.join(room.code, {
-        id: "participant-1",
-        nickname: "Test Bot",
-        model: "llama3",
-        endpoint: "http://localhost:11434",
-      });
-
-      const result = await client.leave(room.code, "participant-1");
-
-      expect(result.success).toBe(true);
+  test("supports heartbeat and remove for participants", async () => {
+    const created = await client.rooms.create({ name: "Lifecycle" });
+    await client.participants.upsert(created.data.room.code, "worker-1", {
+      nickname: "Worker 1",
+      model: "llama3",
+      endpoint: "http://localhost:11434",
     });
 
-    test("throws ClientError for non-existent participant", async () => {
-      const { room } = await client.create("Test Room");
+    const heartbeat = await client.participants.heartbeat(
+      created.data.room.code,
+      "worker-1"
+    );
+    expect(heartbeat.data.success).toBe(true);
+    expect(heartbeat.data.status).toBe("online");
 
-      await expect(client.leave(room.code, "non-existent")).rejects.toThrow(
-        ClientError
-      );
-    });
+    const removed = await client.participants.remove(
+      created.data.room.code,
+      "worker-1"
+    );
+    expect(removed.data.success).toBe(true);
   });
 
-  describe("getParticipants", () => {
-    test("returns participants in room", async () => {
-      const { room } = await client.create("Test Room");
-      await client.join(room.code, {
-        id: "participant-1",
-        nickname: "Test Bot",
-        model: "llama3",
-        endpoint: "http://localhost:11434",
-      });
-
-      const participants = await client.getParticipants(room.code);
-
-      expect(participants).toHaveLength(1);
-      expect(participants[0].nickname).toBe("Test Bot");
-    });
-
-    test("throws ClientError for non-existent room", async () => {
-      await expect(client.getParticipants("XXXXXX")).rejects.toThrow(
-        ClientError
-      );
-    });
+  test("parses typed management errors into ClientError", async () => {
+    await expect(client.rooms.get("XXXXXX")).rejects.toMatchObject({
+      name: "ClientError",
+      status: 404,
+      code: "ROOM_NOT_FOUND",
+    } satisfies Partial<ClientError>);
   });
 
-  describe("healthCheck", () => {
-    test("sends health check for participant", async () => {
-      const { room } = await client.create("Test Room");
-      await client.join(room.code, {
-        id: "participant-1",
-        nickname: "Test Bot",
-        model: "llama3",
-        endpoint: "http://localhost:11434",
-      });
+  test("watches typed room events", async () => {
+    const created = await client.rooms.create({ name: "Watched Room" });
+    const abortController = new AbortController();
+    const iterator = client.events.watchRoom({
+      roomCode: created.data.room.code,
+      signal: abortController.signal,
+    })[Symbol.asyncIterator]();
 
-      const result = await client.healthCheck(room.code, "participant-1");
+    const connectedEvent = await iterator.next();
+    expect(connectedEvent.done).toBe(false);
+    expect(connectedEvent.value?.type).toBe("connected");
 
-      expect(result.success).toBe(true);
+    await client.participants.upsert(created.data.room.code, "worker-1", {
+      nickname: "Worker 1",
+      model: "llama3",
+      endpoint: "http://localhost:11434",
     });
 
-    test("throws ClientError for non-existent participant", async () => {
-      const { room } = await client.create("Test Room");
+    const joinedEvent = await iterator.next();
+    expect(joinedEvent.done).toBe(false);
+    expect(joinedEvent.value?.type).toBe("participant.joined");
 
-      await expect(
-        client.healthCheck(room.code, "non-existent")
-      ).rejects.toThrow(ClientError);
-    });
-  });
-
-  describe("password protection", () => {
-    test("creates password-protected room", async () => {
-      const { room } = await client.create("Secured Room", "secret123");
-
-      expect(room.name).toBe("Secured Room");
-      // Password hash should NOT be exposed in API responses (security)
-    });
-
-    test("allows join with correct password", async () => {
-      const { room } = await client.create("Protected", "mypass");
-
-      const { participant } = await client.join(room.code, {
-        id: "participant-1",
-        nickname: "Test Bot",
-        model: "llama3",
-        endpoint: "http://localhost:11434",
-        password: "mypass",
-      });
-
-      expect(participant.id).toBe("participant-1");
-    });
-
-    test("rejects join with incorrect password", async () => {
-      const { room } = await client.create("Protected", "correctpass");
-
-      await expect(
-        client.join(room.code, {
-          id: "participant-1",
-          nickname: "Test Bot",
-          model: "llama3",
-          endpoint: "http://localhost:11434",
-          password: "wrongpass",
-        })
-      ).rejects.toThrow(ClientError);
-    });
-
-    test("rejects join without password when required", async () => {
-      const { room } = await client.create("Protected", "required");
-
-      await expect(
-        client.join(room.code, {
-          id: "participant-1",
-          nickname: "Test Bot",
-          model: "llama3",
-          endpoint: "http://localhost:11434",
-        })
-      ).rejects.toThrow(ClientError);
-    });
-
-    test("allows join without password when not required", async () => {
-      const { room } = await client.create("Open Room");
-
-      const { participant } = await client.join(room.code, {
-        id: "participant-1",
-        nickname: "Test Bot",
-        model: "llama3",
-        endpoint: "http://localhost:11434",
-      });
-
-      expect(participant.id).toBe("participant-1");
-    });
-  });
-
-  describe("ClientError", () => {
-    test("includes status and response", () => {
-      const error = new ClientError("Test error", 404, { detail: "Not found" });
-
-      expect(error.message).toBe("Test error");
-      expect(error.status).toBe(404);
-      expect(error.response).toEqual({ detail: "Not found" });
-      expect(error.name).toBe("ClientError");
-    });
+    abortController.abort();
   });
 });

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -1,7 +1,16 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import { createHub, type Hub } from "@gambi/core/hub";
 import { Room } from "@gambi/core/room";
-import { ClientError, createClient } from "./client.ts";
+import { type ClientError, createClient } from "./client.ts";
+
+const originalFetch = globalThis.fetch;
 
 function getRandomPort(): number {
   return 30_000 + Math.floor(Math.random() * 20_000);
@@ -36,6 +45,7 @@ describe("HTTP Client", () => {
 
   beforeEach(() => {
     Room.clear();
+    globalThis.fetch = originalFetch;
   });
 
   test("creates and lists rooms through the namespaced client", async () => {
@@ -117,13 +127,44 @@ describe("HTTP Client", () => {
     } satisfies Partial<ClientError>);
   });
 
+  test("maps connectivity failures to ClientError", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("connect ECONNREFUSED"))) as typeof fetch;
+
+    await expect(client.rooms.list()).rejects.toMatchObject({
+      name: "ClientError",
+      status: 503,
+      code: "INTERNAL_ERROR",
+      message: "Failed to reach hub.",
+      hint: "Check hub URL and connectivity.",
+    } satisfies Partial<ClientError>);
+  });
+
+  test("treats invalid success JSON as a protocol ClientError", async () => {
+    globalThis.fetch = (async () =>
+      new Response("not-json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await expect(client.rooms.list()).rejects.toMatchObject({
+      name: "ClientError",
+      status: 502,
+      code: "INTERNAL_ERROR",
+      message: "Invalid JSON response from hub.",
+      hint: "Check hub compatibility or proxy behavior.",
+    } satisfies Partial<ClientError>);
+  });
+
   test("watches typed room events", async () => {
     const created = await client.rooms.create({ name: "Watched Room" });
     const abortController = new AbortController();
-    const iterator = client.events.watchRoom({
-      roomCode: created.data.room.code,
-      signal: abortController.signal,
-    })[Symbol.asyncIterator]();
+    const iterator = client.events
+      .watchRoom({
+        roomCode: created.data.room.code,
+        signal: abortController.signal,
+      })
+      [Symbol.asyncIterator]();
 
     const connectedEvent = await iterator.next();
     expect(connectedEvent.done).toBe(false);
@@ -140,5 +181,24 @@ describe("HTTP Client", () => {
     expect(joinedEvent.value?.type).toBe("participant.joined");
 
     abortController.abort();
+  });
+
+  test("maps room event connectivity failures to ClientError", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("connect ECONNREFUSED"))) as typeof fetch;
+
+    const iterator = client.events
+      .watchRoom({
+        roomCode: "ABC123",
+      })
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toMatchObject({
+      name: "ClientError",
+      status: 503,
+      code: "INTERNAL_ERROR",
+      message: "Failed to reach hub.",
+      hint: "Check hub URL and connectivity.",
+    } satisfies Partial<ClientError>);
   });
 });

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -223,4 +223,35 @@ describe("HTTP Client", () => {
       value: undefined,
     });
   });
+
+  test("maps room event stream interruptions to ClientError", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: "));
+            queueMicrotask(() => {
+              controller.error(new Error("stream dropped"));
+            });
+          },
+        }),
+        {
+          headers: { "Content-Type": "text/event-stream" },
+        }
+      )) as unknown as typeof fetch;
+
+    const iterator = client.events
+      .watchRoom({
+        roomCode: "ABC123",
+      })
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toMatchObject({
+      name: "ClientError",
+      status: 503,
+      code: "INTERNAL_ERROR",
+      message: "Event stream interrupted.",
+      hint: "Check hub URL and connectivity.",
+    } satisfies Partial<ClientError>);
+  });
 });

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -201,4 +201,26 @@ describe("HTTP Client", () => {
       hint: "Check hub URL and connectivity.",
     } satisfies Partial<ClientError>);
   });
+
+  test("ends room event watches cleanly when aborted", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(
+        new DOMException("Aborted", "AbortError")
+      )) as typeof fetch;
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const iterator = client.events
+      .watchRoom({
+        roomCode: "ABC123",
+        signal: abortController.signal,
+      })
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,135 +1,147 @@
-// HTTP client for interacting with remote Gambi hubs
 import type {
+  ApiErrorResponse,
+  ApiMeta,
+  HeartbeatResult,
   ParticipantAuthHeaders,
-  ParticipantInfo,
-  RoomInfoPublic,
+  ParticipantCapabilities,
+  ParticipantSummary,
+  RoomEvent,
+  RoomSummary,
   RuntimeConfig,
 } from "./types.ts";
 
-/**
- * Options for creating a Gambi HTTP client
- */
 export interface ClientOptions {
-  /** Base URL of the hub (default: http://localhost:3000) */
   hubUrl?: string;
 }
 
-/**
- * Options for creating a participant
- */
-export interface CreateParticipantOptions {
-  id: string;
+export interface CreateRoomInput {
+  defaults?: RuntimeConfig;
+  name: string;
+  password?: string;
+}
+
+export interface UpsertParticipantInput {
   nickname: string;
   model: string;
   endpoint: string;
   password?: string;
-  specs?: ParticipantInfo["specs"];
+  specs?: ParticipantSummary["specs"];
   config?: RuntimeConfig;
-  capabilities?: ParticipantInfo["capabilities"];
+  capabilities?: ParticipantCapabilities;
   authHeaders?: ParticipantAuthHeaders;
 }
 
-export interface CreateRoomOptions {
-  password?: string;
-  defaults?: RuntimeConfig;
+export interface ApiResult<T> {
+  data: T;
+  meta: ApiMeta;
 }
 
-/**
- * Response when creating a room
- */
-export interface CreateRoomResponse {
-  room: RoomInfoPublic;
-  hostId: string;
+export interface WatchRoomOptions {
+  roomCode: string;
+  signal?: AbortSignal;
 }
 
-/**
- * Response when joining a room
- */
-export interface JoinRoomResponse {
-  participant: ParticipantInfo;
-  roomId: string;
-}
-
-/**
- * HTTP client for interacting with a remote Gambi hub
- *
- * Provides methods for managing rooms and participants via HTTP.
- */
 export interface GambiClient {
-  /** Create a new room with an optional password and runtime defaults */
-  create(
-    name: string,
-    passwordOrOptions?: string | CreateRoomOptions
-  ): Promise<CreateRoomResponse>;
-
-  /** List all rooms */
-  list(): Promise<RoomInfoPublic[]>;
-
-  /** Join a room as a participant */
-  join(
-    code: string,
-    participant: CreateParticipantOptions
-  ): Promise<JoinRoomResponse>;
-
-  /** Leave a room */
-  leave(code: string, participantId: string): Promise<{ success: boolean }>;
-
-  /** Get all participants in a room */
-  getParticipants(code: string): Promise<ParticipantInfo[]>;
-
-  /** Send health check for a participant */
-  healthCheck(
-    code: string,
-    participantId: string
-  ): Promise<{ success: boolean }>;
+  rooms: {
+    create: (
+      input: CreateRoomInput
+    ) => Promise<ApiResult<{ room: RoomSummary; hostId: string }>>;
+    get: (roomCode: string) => Promise<ApiResult<RoomSummary>>;
+    list: () => Promise<ApiResult<RoomSummary[]>>;
+  };
+  participants: {
+    upsert: (
+      roomCode: string,
+      participantId: string,
+      input: UpsertParticipantInput
+    ) => Promise<ApiResult<{ participant: ParticipantSummary; roomId: string }>>;
+    list: (roomCode: string) => Promise<ApiResult<ParticipantSummary[]>>;
+    remove: (
+      roomCode: string,
+      participantId: string
+    ) => Promise<ApiResult<{ success: true }>>;
+    heartbeat: (
+      roomCode: string,
+      participantId: string
+    ) => Promise<ApiResult<HeartbeatResult>>;
+  };
+  events: {
+    watchRoom: (options: WatchRoomOptions) => AsyncIterable<RoomEvent>;
+  };
 }
 
-/**
- * Error thrown when a client request fails
- */
 export class ClientError extends Error {
   readonly status: number;
-  readonly response?: unknown;
+  readonly code?: string;
+  readonly hint?: string;
+  readonly details?: unknown;
+  readonly requestId?: string;
 
-  constructor(message: string, status: number, response?: unknown) {
-    super(message);
+  constructor(params: {
+    message: string;
+    status: number;
+    code?: string;
+    hint?: string;
+    details?: unknown;
+    requestId?: string;
+  }) {
+    super(params.message);
     this.name = "ClientError";
-    this.status = status;
-    this.response = response;
+    this.status = params.status;
+    this.code = params.code;
+    this.hint = params.hint;
+    this.details = params.details;
+    this.requestId = params.requestId;
   }
 }
 
-/**
- * Create a new Gambi HTTP client
- *
- * @param options - Client configuration options
- * @returns A client instance for interacting with the hub
- *
- * @example
- * ```typescript
- * import { createClient } from "gambi-sdk/client";
- *
- * const client = createClient({ hubUrl: "http://hub.example.com:3000" });
- *
- * // Create a password-protected room
- * const { room, hostId } = await client.create("My Room", "secret123");
- *
- * // Join the room with password
- * await client.join(room.code, {
- *   id: "participant-1",
- *   nickname: "Bot",
- *   model: "llama3",
- *   endpoint: "http://localhost:11434",
- *   password: "secret123"
- * });
- * ```
- */
+function parseErrorEnvelope(
+  status: number,
+  body: Partial<ApiErrorResponse> | undefined,
+  fallbackMessage: string
+): ClientError {
+  return new ClientError({
+    message: body?.error?.message ?? fallbackMessage,
+    status,
+    code: body?.error?.code,
+    hint: body?.error?.hint,
+    details: body?.error?.details,
+    requestId: body?.meta?.requestId,
+  });
+}
+
+function parseEventStreamChunk(chunk: string): RoomEvent[] {
+  const events: RoomEvent[] = [];
+  const blocks = chunk.split("\n\n");
+
+  for (const block of blocks) {
+    if (!block.trim()) {
+      continue;
+    }
+
+    const eventLine = block
+      .split("\n")
+      .find((line) => line.startsWith("data: "));
+    if (!eventLine) {
+      continue;
+    }
+
+    try {
+      const data = JSON.parse(eventLine.slice(6)) as RoomEvent;
+      events.push(data);
+    } catch {
+      continue;
+    }
+  }
+
+  return events;
+}
+
 export function createClient(options: ClientOptions = {}): GambiClient {
   const hubUrl = options.hubUrl ?? "http://localhost:3000";
 
-  async function request<T>(path: string, init?: RequestInit): Promise<T> {
-    const url = `${hubUrl}${path}`;
-    const response = await fetch(url, {
+  async function request<T>(path: string, init?: RequestInit): Promise<ApiResult<T>> {
+    const response = await fetch(`${hubUrl}${path}`, {
       ...init,
       headers: {
         "Content-Type": "application/json",
@@ -137,82 +149,124 @@ export function createClient(options: ClientOptions = {}): GambiClient {
       },
     });
 
+    const body = (await response.json().catch(() => undefined)) as
+      | ApiResult<T>
+      | ApiErrorResponse
+      | undefined;
+
     if (!response.ok) {
-      const errorData = (await response.json().catch(() => ({}))) as {
-        error?: string;
-      };
-      throw new ClientError(
-        errorData.error || `Request failed: ${response.statusText}`,
+      throw parseErrorEnvelope(
         response.status,
-        errorData
+        body as Partial<ApiErrorResponse> | undefined,
+        `Request failed: ${response.statusText}`
       );
     }
 
-    return response.json() as Promise<T>;
+    return body as ApiResult<T>;
   }
 
   return {
-    create(
-      name: string,
-      passwordOrOptions?: string | CreateRoomOptions
-    ): Promise<CreateRoomResponse> {
-      const createOptions =
-        typeof passwordOrOptions === "string"
-          ? { password: passwordOrOptions }
-          : passwordOrOptions;
-      const body: {
-        defaults?: RuntimeConfig;
-        name: string;
-        password?: string;
-      } = { name };
-      if (createOptions?.password) {
-        body.password = createOptions.password;
-      }
-      if (createOptions?.defaults) {
-        body.defaults = createOptions.defaults;
-      }
-      return request("/rooms", {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
+    rooms: {
+      create(input) {
+        return request<{ room: RoomSummary; hostId: string }>("/v1/rooms", {
+          method: "POST",
+          body: JSON.stringify(input),
+        });
+      },
+      get(roomCode) {
+        return request<RoomSummary>(`/v1/rooms/${roomCode}`);
+      },
+      list() {
+        return request<RoomSummary[]>("/v1/rooms");
+      },
     },
-
-    async list(): Promise<RoomInfoPublic[]> {
-      const response = await request<{ rooms: RoomInfoPublic[] }>("/rooms");
-      return response.rooms;
+    participants: {
+      upsert(roomCode, participantId, input) {
+        return request<{ participant: ParticipantSummary; roomId: string }>(
+          `/v1/rooms/${roomCode}/participants/${participantId}`,
+          {
+            method: "PUT",
+            body: JSON.stringify(input),
+          }
+        );
+      },
+      list(roomCode) {
+        return request<ParticipantSummary[]>(
+          `/v1/rooms/${roomCode}/participants`
+        );
+      },
+      remove(roomCode, participantId) {
+        return request<{ success: true }>(
+          `/v1/rooms/${roomCode}/participants/${participantId}`,
+          {
+            method: "DELETE",
+          }
+        );
+      },
+      heartbeat(roomCode, participantId) {
+        return request<HeartbeatResult>(
+          `/v1/rooms/${roomCode}/participants/${participantId}/heartbeat`,
+          {
+            method: "POST",
+          }
+        );
+      },
     },
+    events: {
+      async *watchRoom(options: WatchRoomOptions): AsyncIterable<RoomEvent> {
+        const response = await fetch(
+          `${hubUrl}/v1/rooms/${options.roomCode}/events`,
+          {
+            headers: { Accept: "text/event-stream" },
+            signal: options.signal,
+          }
+        );
 
-    join(
-      code: string,
-      participant: CreateParticipantOptions
-    ): Promise<JoinRoomResponse> {
-      return request(`/rooms/${code}/join`, {
-        method: "POST",
-        body: JSON.stringify(participant),
-      });
-    },
+        if (!response.ok) {
+          const body = (await response.json().catch(() => undefined)) as
+            | ApiErrorResponse
+            | undefined;
+          throw parseErrorEnvelope(
+            response.status,
+            body,
+            `Failed to watch room events: ${response.statusText}`
+          );
+        }
 
-    leave(code: string, participantId: string): Promise<{ success: boolean }> {
-      return request(`/rooms/${code}/leave/${participantId}`, {
-        method: "DELETE",
-      });
-    },
+        if (!response.body) {
+          throw new ClientError({
+            message: "Event stream body is missing.",
+            status: 500,
+            code: "INTERNAL_ERROR",
+          });
+        }
 
-    async getParticipants(code: string): Promise<ParticipantInfo[]> {
-      const response = await request<{ participants: ParticipantInfo[] }>(
-        `/rooms/${code}/participants`
-      );
-      return response.participants;
-    },
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
 
-    healthCheck(
-      code: string,
-      participantId: string
-    ): Promise<{ success: boolean }> {
-      return request(`/rooms/${code}/health`, {
-        method: "POST",
-        body: JSON.stringify({ id: participantId }),
-      });
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const split = buffer.split("\n\n");
+          buffer = split.pop() ?? "";
+          for (const block of split) {
+            for (const event of parseEventStreamChunk(`${block}\n\n`)) {
+              yield event;
+            }
+          }
+        }
+
+        if (buffer.trim()) {
+          for (const event of parseEventStreamChunk(buffer)) {
+            yield event;
+          }
+        }
+      },
     },
   };
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -112,6 +112,63 @@ export function parseErrorEnvelope(
   });
 }
 
+function isApiResult<T>(value: unknown): value is ApiResult<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    "meta" in value
+  );
+}
+
+function createConnectivityError(
+  message = "Failed to reach hub.",
+  hint = "Check hub URL and connectivity."
+): ClientError {
+  return new ClientError({
+    message,
+    status: 503,
+    code: "INTERNAL_ERROR",
+    hint,
+  });
+}
+
+function createProtocolError(
+  message = "Invalid JSON response from hub.",
+  hint = "Check hub compatibility or proxy behavior."
+): ClientError {
+  return new ClientError({
+    message,
+    status: 502,
+    code: "INTERNAL_ERROR",
+    hint,
+  });
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchResponse(
+  input: string,
+  init?: RequestInit
+): Promise<Response> {
+  try {
+    return await fetch(input, init);
+  } catch {
+    throw createConnectivityError();
+  }
+}
+
 function parseEventStreamChunk(chunk: string): RoomEvent[] {
   const events: RoomEvent[] = [];
   const blocks = chunk.split("\n\n");
@@ -139,6 +196,43 @@ function parseEventStreamChunk(chunk: string): RoomEvent[] {
   return events;
 }
 
+async function* streamRoomEvents(response: Response): AsyncIterable<RoomEvent> {
+  if (!response.body) {
+    throw new ClientError({
+      message: "Event stream body is missing.",
+      status: 500,
+      code: "INTERNAL_ERROR",
+    });
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const split = buffer.split("\n\n");
+    buffer = split.pop() ?? "";
+    for (const block of split) {
+      for (const event of parseEventStreamChunk(`${block}\n\n`)) {
+        yield event;
+      }
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.trim()) {
+    for (const event of parseEventStreamChunk(buffer)) {
+      yield event;
+    }
+  }
+}
+
 export function createClient(options: ClientOptions = {}): GambiClient {
   const hubUrl = options.hubUrl ?? "http://localhost:3000";
 
@@ -146,7 +240,7 @@ export function createClient(options: ClientOptions = {}): GambiClient {
     path: string,
     init?: RequestInit
   ): Promise<ApiResult<T>> {
-    const response = await fetch(`${hubUrl}${path}`, {
+    const response = await fetchResponse(`${hubUrl}${path}`, {
       ...init,
       headers: {
         "Content-Type": "application/json",
@@ -154,7 +248,7 @@ export function createClient(options: ClientOptions = {}): GambiClient {
       },
     });
 
-    const body = (await response.json().catch(() => undefined)) as
+    const body = (await readJsonBody(response)) as
       | ApiResult<T>
       | ApiErrorResponse
       | undefined;
@@ -167,7 +261,11 @@ export function createClient(options: ClientOptions = {}): GambiClient {
       );
     }
 
-    return body as ApiResult<T>;
+    if (!isApiResult<T>(body)) {
+      throw createProtocolError();
+    }
+
+    return body;
   }
 
   return {
@@ -219,7 +317,7 @@ export function createClient(options: ClientOptions = {}): GambiClient {
     },
     events: {
       async *watchRoom(options: WatchRoomOptions): AsyncIterable<RoomEvent> {
-        const response = await fetch(
+        const response = await fetchResponse(
           `${hubUrl}/v1/rooms/${options.roomCode}/events`,
           {
             headers: { Accept: "text/event-stream" },
@@ -228,7 +326,7 @@ export function createClient(options: ClientOptions = {}): GambiClient {
         );
 
         if (!response.ok) {
-          const body = (await response.json().catch(() => undefined)) as
+          const body = (await readJsonBody(response)) as
             | ApiErrorResponse
             | undefined;
           throw parseErrorEnvelope(
@@ -238,38 +336,8 @@ export function createClient(options: ClientOptions = {}): GambiClient {
           );
         }
 
-        if (!response.body) {
-          throw new ClientError({
-            message: "Event stream body is missing.",
-            status: 500,
-            code: "INTERNAL_ERROR",
-          });
-        }
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) {
-            break;
-          }
-
-          buffer += decoder.decode(value, { stream: true });
-          const split = buffer.split("\n\n");
-          buffer = split.pop() ?? "";
-          for (const block of split) {
-            for (const event of parseEventStreamChunk(`${block}\n\n`)) {
-              yield event;
-            }
-          }
-        }
-
-        if (buffer.trim()) {
-          for (const event of parseEventStreamChunk(buffer)) {
-            yield event;
-          }
+        for await (const event of streamRoomEvents(response)) {
+          yield event;
         }
       },
     },

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -112,6 +112,12 @@ export function parseErrorEnvelope(
   });
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}
+
 function isApiResult<T>(value: unknown): value is ApiResult<T> {
   return (
     typeof value === "object" &&
@@ -164,7 +170,10 @@ async function fetchResponse(
 ): Promise<Response> {
   try {
     return await fetch(input, init);
-  } catch {
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
     throw createConnectivityError();
   }
 }
@@ -210,7 +219,17 @@ async function* streamRoomEvents(response: Response): AsyncIterable<RoomEvent> {
   let buffer = "";
 
   while (true) {
-    const { done, value } = await reader.read();
+    let chunk;
+    try {
+      chunk = await reader.read();
+    } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
+      throw error;
+    }
+
+    const { done, value } = chunk;
     if (done) {
       break;
     }
@@ -317,13 +336,21 @@ export function createClient(options: ClientOptions = {}): GambiClient {
     },
     events: {
       async *watchRoom(options: WatchRoomOptions): AsyncIterable<RoomEvent> {
-        const response = await fetchResponse(
-          `${hubUrl}/v1/rooms/${options.roomCode}/events`,
-          {
-            headers: { Accept: "text/event-stream" },
-            signal: options.signal,
+        let response: Response;
+        try {
+          response = await fetchResponse(
+            `${hubUrl}/v1/rooms/${options.roomCode}/events`,
+            {
+              headers: { Accept: "text/event-stream" },
+              signal: options.signal,
+            }
+          );
+        } catch (error) {
+          if (isAbortError(error)) {
+            return;
           }
-        );
+          throw error;
+        }
 
         if (!response.ok) {
           const body = (await readJsonBody(response)) as

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -216,17 +216,18 @@ async function* streamRoomEvents(response: Response): AsyncIterable<RoomEvent> {
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
+  type ReaderChunk = Awaited<ReturnType<typeof reader.read>>;
   let buffer = "";
 
   while (true) {
-    let chunk;
+    let chunk: ReaderChunk;
     try {
       chunk = await reader.read();
     } catch (error) {
       if (isAbortError(error)) {
         return;
       }
-      throw error;
+      throw createConnectivityError("Event stream interrupted.");
     }
 
     const { done, value } = chunk;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -54,7 +54,9 @@ export interface GambiClient {
       roomCode: string,
       participantId: string,
       input: UpsertParticipantInput
-    ) => Promise<ApiResult<{ participant: ParticipantSummary; roomId: string }>>;
+    ) => Promise<
+      ApiResult<{ participant: ParticipantSummary; roomId: string }>
+    >;
     list: (roomCode: string) => Promise<ApiResult<ParticipantSummary[]>>;
     remove: (
       roomCode: string,
@@ -95,7 +97,7 @@ export class ClientError extends Error {
   }
 }
 
-function parseErrorEnvelope(
+export function parseErrorEnvelope(
   status: number,
   body: Partial<ApiErrorResponse> | undefined,
   fallbackMessage: string
@@ -130,7 +132,7 @@ function parseEventStreamChunk(chunk: string): RoomEvent[] {
       const data = JSON.parse(eventLine.slice(6)) as RoomEvent;
       events.push(data);
     } catch {
-      continue;
+      // Ignore malformed SSE payloads and keep the stream parser resilient.
     }
   }
 
@@ -140,7 +142,10 @@ function parseEventStreamChunk(chunk: string): RoomEvent[] {
 export function createClient(options: ClientOptions = {}): GambiClient {
   const hubUrl = options.hubUrl ?? "http://localhost:3000";
 
-  async function request<T>(path: string, init?: RequestInit): Promise<ApiResult<T>> {
+  async function request<T>(
+    path: string,
+    init?: RequestInit
+  ): Promise<ApiResult<T>> {
     const response = await fetch(`${hubUrl}${path}`, {
       ...init,
       headers: {

--- a/packages/sdk/src/discovery.test.ts
+++ b/packages/sdk/src/discovery.test.ts
@@ -49,9 +49,12 @@ describe("SDK discovery", () => {
       fetchFn: (input) => {
         const url = String(input);
 
-        if (url === "http://localhost:3000/health") {
+        if (url === "http://localhost:3000/v1/health") {
           return Promise.resolve(
-            Response.json({ status: "ok", timestamp: Date.now() })
+            Response.json({
+              data: { status: "ok", timestamp: Date.now() },
+              meta: { requestId: "req-local" },
+            })
           );
         }
 
@@ -75,9 +78,12 @@ describe("SDK discovery", () => {
       fetchFn: (input) => {
         const url = String(input);
 
-        if (url === "http://localhost:3000/health") {
+        if (url === "http://localhost:3000/v1/health") {
           return Promise.resolve(
-            Response.json({ status: "ok", timestamp: Date.now() })
+            Response.json({
+              data: { status: "ok", timestamp: Date.now() },
+              meta: { requestId: "req-local" },
+            })
           );
         }
 
@@ -104,15 +110,21 @@ describe("SDK discovery", () => {
     const fetchFn: FetchLike = (input) => {
       const url = String(input);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({
+            data: { status: "ok", timestamp: Date.now() },
+            meta: { requestId: "req-local" },
+          })
         );
       }
 
-      if (url === "http://192.168.1.40:3100/health") {
+      if (url === "http://192.168.1.40:3100/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({
+            data: { status: "ok", timestamp: Date.now() },
+            meta: { requestId: "req-remote" },
+          })
         );
       }
 
@@ -162,24 +174,40 @@ describe("SDK discovery", () => {
       const url = String(input);
       fetchCalls.push(url);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({
+            data: { status: "ok", timestamp: Date.now() },
+            meta: { requestId: "req-local" },
+          })
         );
       }
 
-      if (url === "http://localhost:3000/rooms") {
-        return Promise.resolve(Response.json({ rooms: [alphaRoom] }));
-      }
-
-      if (url === "http://192.168.1.40:3100/health") {
+      if (url === "http://localhost:3000/v1/rooms") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({
+            data: [alphaRoom],
+            meta: { requestId: "req-rooms-local" },
+          })
         );
       }
 
-      if (url === "http://192.168.1.40:3100/rooms") {
-        return Promise.resolve(Response.json({ rooms: [betaRoom] }));
+      if (url === "http://192.168.1.40:3100/v1/health") {
+        return Promise.resolve(
+          Response.json({
+            data: { status: "ok", timestamp: Date.now() },
+            meta: { requestId: "req-remote" },
+          })
+        );
+      }
+
+      if (url === "http://192.168.1.40:3100/v1/rooms") {
+        return Promise.resolve(
+          Response.json({
+            data: [betaRoom],
+            meta: { requestId: "req-rooms-remote" },
+          })
+        );
       }
 
       throw new Error(`Unexpected URL: ${url}`);
@@ -205,10 +233,10 @@ describe("SDK discovery", () => {
     expect(target.roomCode).toBe("XYZ999");
     expect(target.room.name).toBe("Beta");
     expect(fetchCalls).toEqual([
-      "http://localhost:3000/health",
-      "http://192.168.1.40:3100/health",
-      "http://localhost:3000/rooms",
-      "http://192.168.1.40:3100/rooms",
+      "http://localhost:3000/v1/health",
+      "http://192.168.1.40:3100/v1/health",
+      "http://localhost:3000/v1/rooms",
+      "http://192.168.1.40:3100/v1/rooms",
     ]);
 
     const provider = createGambi(target);
@@ -219,14 +247,22 @@ describe("SDK discovery", () => {
     const fetchFn: FetchLike = (input) => {
       const url = String(input);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(
-          Response.json({ status: "ok", timestamp: Date.now() })
+          Response.json({
+            data: { status: "ok", timestamp: Date.now() },
+            meta: { requestId: "req-local" },
+          })
         );
       }
 
-      if (url === "http://localhost:3000/rooms") {
-        return Promise.resolve(Response.json({ rooms: [alphaRoom, betaRoom] }));
+      if (url === "http://localhost:3000/v1/rooms") {
+        return Promise.resolve(
+          Response.json({
+            data: [alphaRoom, betaRoom],
+            meta: { requestId: "req-rooms-local" },
+          })
+        );
       }
 
       throw new Error(`Unexpected URL: ${url}`);
@@ -252,7 +288,7 @@ describe("SDK discovery", () => {
     const fetchFn: FetchLike = (input) => {
       const url = String(input);
 
-      if (url === "http://localhost:3000/health") {
+      if (url === "http://localhost:3000/v1/health") {
         return Promise.resolve(new Response("offline", { status: 503 }));
       }
 

--- a/packages/sdk/src/provider.test.ts
+++ b/packages/sdk/src/provider.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ClientError } from "./client.ts";
 import { createGambi } from "./provider.ts";
 
+const originalFetch = globalThis.fetch;
+
 describe("SDK provider", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   test("defaults to OpenResponses", () => {
     const provider = createGambi({ roomCode: "ABC123" });
 
@@ -20,5 +27,33 @@ describe("SDK provider", () => {
     expect(provider.defaultProtocol).toBe("chatCompletions");
     expect(provider.participant("participant-1")).toBeDefined();
     expect(provider.model("llama3")).toBeDefined();
+  });
+
+  test("surfaces typed management errors from listParticipants", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "ROOM_NOT_FOUND",
+            message: "Room not found.",
+            hint: "Run 'gambi room list' to inspect available rooms.",
+          },
+          meta: { requestId: "req_123" },
+        }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }
+      )) as typeof fetch;
+
+    const provider = createGambi({ roomCode: "ABC123" });
+
+    await expect(provider.listParticipants()).rejects.toMatchObject({
+      name: "ClientError",
+      status: 404,
+      code: "ROOM_NOT_FOUND",
+      hint: "Run 'gambi room list' to inspect available rooms.",
+      requestId: "req_123",
+    } satisfies Partial<ClientError>);
   });
 });

--- a/packages/sdk/src/provider.test.ts
+++ b/packages/sdk/src/provider.test.ts
@@ -56,4 +56,22 @@ describe("SDK provider", () => {
       requestId: "req_123",
     } satisfies Partial<ClientError>);
   });
+
+  test("treats invalid success JSON as a protocol ClientError", async () => {
+    globalThis.fetch = (async () =>
+      new Response("not-json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    const provider = createGambi({ roomCode: "ABC123" });
+
+    await expect(provider.listParticipants()).rejects.toMatchObject({
+      name: "ClientError",
+      status: 502,
+      code: "INTERNAL_ERROR",
+      message: "Invalid JSON response from hub.",
+      hint: "Check hub compatibility or proxy behavior.",
+    } satisfies Partial<ClientError>);
+  });
 });

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -1,7 +1,8 @@
 import { createOpenResponses } from "@ai-sdk/open-responses";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import type { ParticipantInfo } from "@gambi/core/types";
+import type { ApiErrorResponse, ParticipantInfo } from "@gambi/core/types";
+import { parseErrorEnvelope } from "./client.ts";
 
 export type GambiProtocol = "openResponses" | "chatCompletions";
 const DEFAULT_PROTOCOL: GambiProtocol = "openResponses";
@@ -118,9 +119,18 @@ export function createGambi(options: GambiOptions): GambiProvider {
     defaultProtocol,
 
     async listParticipants(): Promise<ParticipantInfo[]> {
-      const response = await fetch(`${hubUrl}/v1/rooms/${options.roomCode}/participants`);
+      const response = await fetch(
+        `${hubUrl}/v1/rooms/${options.roomCode}/participants`
+      );
       if (!response.ok) {
-        throw new Error(`Failed to fetch participants: ${response.statusText}`);
+        const body = (await response.json().catch(() => undefined)) as
+          | Partial<ApiErrorResponse>
+          | undefined;
+        throw parseErrorEnvelope(
+          response.status,
+          body,
+          `Failed to fetch participants: ${response.statusText}`
+        );
       }
       const data = (await response.json()) as ParticipantsResponse;
       return data.data;

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -2,7 +2,7 @@ import { createOpenResponses } from "@ai-sdk/open-responses";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ApiErrorResponse, ParticipantInfo } from "@gambi/core/types";
-import { parseErrorEnvelope } from "./client.ts";
+import { ClientError, parseErrorEnvelope } from "./client.ts";
 
 export type GambiProtocol = "openResponses" | "chatCompletions";
 const DEFAULT_PROTOCOL: GambiProtocol = "openResponses";
@@ -95,6 +95,28 @@ function createNamespace(
   return protocolNamespaceFactories[protocol](baseURL);
 }
 
+function isParticipantsResponse(value: unknown): value is ParticipantsResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    Array.isArray(value.data)
+  );
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Create a Gambi provider for use with AI SDK.
  *
@@ -123,7 +145,7 @@ export function createGambi(options: GambiOptions): GambiProvider {
         `${hubUrl}/v1/rooms/${options.roomCode}/participants`
       );
       if (!response.ok) {
-        const body = (await response.json().catch(() => undefined)) as
+        const body = (await readJsonBody(response)) as
           | Partial<ApiErrorResponse>
           | undefined;
         throw parseErrorEnvelope(
@@ -132,8 +154,17 @@ export function createGambi(options: GambiOptions): GambiProvider {
           `Failed to fetch participants: ${response.statusText}`
         );
       }
-      const data = (await response.json()) as ParticipantsResponse;
-      return data.data;
+      const body = await readJsonBody(response);
+      if (!isParticipantsResponse(body)) {
+        throw new ClientError({
+          message: "Invalid JSON response from hub.",
+          status: 502,
+          code: "INTERNAL_ERROR",
+          hint: "Check hub compatibility or proxy behavior.",
+        });
+      }
+
+      return body.data;
     },
 
     async listModels(): Promise<GambiModel[]> {

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -21,7 +21,7 @@ export interface GambiModel {
 }
 
 interface ParticipantsResponse {
-  participants: ParticipantInfo[];
+  data: ParticipantInfo[];
 }
 
 interface ModelsResponse {
@@ -118,14 +118,12 @@ export function createGambi(options: GambiOptions): GambiProvider {
     defaultProtocol,
 
     async listParticipants(): Promise<ParticipantInfo[]> {
-      const response = await fetch(
-        `${hubUrl}/rooms/${options.roomCode}/participants`
-      );
+      const response = await fetch(`${hubUrl}/v1/rooms/${options.roomCode}/participants`);
       if (!response.ok) {
         throw new Error(`Failed to fetch participants: ${response.statusText}`);
       }
       const data = (await response.json()) as ParticipantsResponse;
-      return data.participants;
+      return data.data;
     },
 
     async listModels(): Promise<GambiModel[]> {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2,6 +2,10 @@
 
 // Type exports
 export type {
+  ApiErrorCode,
+  ApiErrorResponse,
+  ApiErrorShape,
+  ApiMeta,
   ChatCompletion,
   ChatCompletionChunk,
   ChatCompletionCreateParams,
@@ -9,6 +13,7 @@ export type {
   ChatCompletionMessageParam,
   GenerationConfig,
   HubConfig,
+  HeartbeatResult,
   InputItemListParams,
   LlmMetrics,
   MachineSpecs,
@@ -21,7 +26,10 @@ export type {
   ParticipantInfo,
   ParticipantInfoInternal,
   ParticipantRegistration,
+  ParticipantSummary,
   ParticipantStatus,
+  RoomEvent,
+  RoomEventType,
   Response,
   ResponseCreateParams,
   ResponseCreateParamsNonStreaming,
@@ -35,15 +43,21 @@ export type {
   ResponseUsage,
   RoomInfo,
   RoomInfoPublic,
+  RoomSummary,
   RuntimeConfig,
   RuntimeConfigPublic,
 } from "@gambi/core/types";
 // Re-export Zod schemas for runtime validation (with Schema suffix to avoid conflicts)
 // Re-export constants
 export {
+  ApiErrorCode as ApiErrorCodeSchema,
+  ApiErrorResponse as ApiErrorResponseSchema,
+  ApiErrorShape as ApiErrorShapeSchema,
+  ApiMeta as ApiMetaSchema,
   GenerationConfig as GenerationConfigSchema,
   HEALTH_CHECK_INTERVAL,
   HubConfig as HubConfigSchema,
+  HeartbeatResult as HeartbeatResultSchema,
   LlmMetrics as LlmMetricsSchema,
   MachineSpecs as MachineSpecsSchema,
   NetworkConfig as NetworkConfigSchema,
@@ -53,9 +67,13 @@ export {
   ParticipantInfo as ParticipantInfoSchema,
   ParticipantInfoInternal as ParticipantInfoInternalSchema,
   ParticipantRegistration as ParticipantRegistrationSchema,
+  ParticipantSummary as ParticipantSummarySchema,
   ParticipantStatus as ParticipantStatusSchema,
+  RoomEvent as RoomEventSchema,
+  RoomEventType as RoomEventTypeSchema,
   RoomInfoInternal as RoomInfoSchema,
   RoomInfoPublic as RoomInfoPublicSchema,
+  RoomSummary as RoomSummarySchema,
   RuntimeConfig as RuntimeConfigSchema,
   RuntimeConfigPublic as RuntimeConfigPublicSchema,
 } from "@gambi/core/types";


### PR DESCRIPTION
## Summary
- Redesigned the hub around a split model: native management APIs under `/v1` and room-scoped OpenAI-compatible inference APIs under `/rooms/:code/v1/*`.
- Reworked the CLI into resource-oriented commands for hub, room, participant, events, and self-update workflows, with structured output and non-interactive flags.
- Updated the SDK to expose management clients, discovery helpers, and room-scoped inference providers aligned with the new core contracts.
- Refreshed the TUI, core hub, SSE, discovery, and docs to match the new APIs and operational model.
- Expanded and revised documentation to describe the new architecture, CLI usage, SDK usage, and HTTP reference.

## Testing
- Not run (PR content prepared from the provided diff/commit summary).
- Relevant checks in this branch include `bun run check-types`, `bun run --cwd apps/tui test`, and workspace-specific build/typecheck commands for `packages/core`, `packages/cli`, and `packages/sdk`.