### PR TITLE
fix(tui): use tunnel-first participant sessions

### DIFF
--- a/apps/tui/src/app.tsx
+++ b/apps/tui/src/app.tsx
@@ -1,5 +1,5 @@
 import { useKeyboard, useRenderer } from "@opentui/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { AddRoomModal } from "./components/add-room-modal";
 import { ConfirmModal } from "./components/confirm-modal";
 import { Footer } from "./components/footer";
@@ -15,12 +15,7 @@ import { ListRooms } from "./screens/list-rooms";
 import { MainMenu } from "./screens/main-menu";
 import { Monitor } from "./screens/monitor";
 import { ServeHub } from "./screens/serve-hub";
-import { useAppStore } from "./store/app-store";
 import { shutdownHub, useHubStore } from "./store/hub-store";
-
-interface AppProps {
-  hubUrl: string;
-}
 
 // Layout wrapper that includes sidebar and notifications
 function WithSidebar({ children }: { children: React.ReactNode }) {
@@ -39,20 +34,14 @@ function WithSidebar({ children }: { children: React.ReactNode }) {
 
 type ConfirmAction = "quit" | "leave" | null;
 
-export function App({ hubUrl: initialHubUrl }: AppProps) {
+export function App() {
   const renderer = useRenderer();
-  const setHubUrl = useAppStore((s) => s.setHubUrl);
   const hubStatus = useHubStore((s) => s.status);
   const session = useParticipantSession();
 
   // Confirmation modal state
   const [pendingConfirm, setPendingConfirm] = useState<ConfirmAction>(null);
   const [isQuitting, setIsQuitting] = useState(false);
-
-  // Initialize store with prop value
-  useEffect(() => {
-    setHubUrl(initialHubUrl);
-  }, [initialHubUrl, setHubUrl]);
 
   // Run periodic health checks on the local hub
   useHubHealthQuery();

--- a/apps/tui/src/app.tsx
+++ b/apps/tui/src/app.tsx
@@ -47,6 +47,7 @@ export function App({ hubUrl: initialHubUrl }: AppProps) {
 
   // Confirmation modal state
   const [pendingConfirm, setPendingConfirm] = useState<ConfirmAction>(null);
+  const [isQuitting, setIsQuitting] = useState(false);
 
   // Initialize store with prop value
   useEffect(() => {
@@ -70,30 +71,46 @@ export function App({ hubUrl: initialHubUrl }: AppProps) {
   } = useRooms();
 
   // Check if confirmation is needed before quitting
-  const needsQuitConfirmation =
-    hubStatus === "running" || session.status === "joined";
+  const hasActiveSession =
+    session.status === "joining" ||
+    session.status === "joined" ||
+    session.status === "leaving";
+  const needsQuitConfirmation = hubStatus === "running" || hasActiveSession;
 
-  const doQuit = useCallback(() => {
+  const doQuit = useCallback(async () => {
+    if (isQuitting) {
+      return;
+    }
+    setIsQuitting(true);
+    if (hasActiveSession) {
+      await session.leave();
+    }
     shutdownHub();
     renderer.destroy();
-  }, [renderer]);
+  }, [renderer, session, hasActiveSession, isQuitting]);
 
   const handleQuit = useCallback(() => {
+    if (isQuitting) {
+      return;
+    }
     if (needsQuitConfirmation) {
       setPendingConfirm("quit");
     } else {
-      doQuit();
+      void doQuit();
     }
-  }, [needsQuitConfirmation, doQuit]);
+  }, [needsQuitConfirmation, doQuit, isQuitting]);
 
   const handleConfirm = useCallback(() => {
+    if (isQuitting) {
+      return;
+    }
     if (pendingConfirm === "quit") {
-      doQuit();
+      void doQuit();
     } else if (pendingConfirm === "leave") {
-      session.leave();
+      void session.leave();
     }
     setPendingConfirm(null);
-  }, [pendingConfirm, doQuit, session]);
+  }, [pendingConfirm, doQuit, session, isQuitting]);
 
   const handleCancelConfirm = useCallback(() => {
     setPendingConfirm(null);
@@ -144,18 +161,32 @@ export function App({ hubUrl: initialHubUrl }: AppProps) {
   );
 
   // Confirmation Modal
+  if (isQuitting) {
+    return (
+      <WithSidebar>
+        <box alignItems="center" flexGrow={1} justifyContent="center">
+          <text>Leaving participant session and shutting down...</text>
+        </box>
+      </WithSidebar>
+    );
+  }
+
   if (pendingConfirm === "quit") {
     const reasons: string[] = [];
     if (hubStatus === "running") {
       reasons.push("Hub is running");
     }
-    if (session.status === "joined") {
+    if (hasActiveSession) {
       reasons.push("You are joined in a room");
     }
     return (
       <WithSidebar>
         <ConfirmModal
-          message={`${reasons.join(" and ")}. Are you sure you want to quit?`}
+          message={
+            isQuitting
+              ? "Closing participant tunnel..."
+              : `${reasons.join(" and ")}. Are you sure you want to quit?`
+          }
           onCancel={handleCancelConfirm}
           onConfirm={handleConfirm}
           title="Confirm Quit"

--- a/apps/tui/src/app.tsx
+++ b/apps/tui/src/app.tsx
@@ -16,6 +16,7 @@ import { MainMenu } from "./screens/main-menu";
 import { Monitor } from "./screens/monitor";
 import { ServeHub } from "./screens/serve-hub";
 import { shutdownHub, useHubStore } from "./store/hub-store";
+import { useSessionStore } from "./store/session-store";
 
 // Layout wrapper that includes sidebar and notifications
 function WithSidebar({ children }: { children: React.ReactNode }) {
@@ -71,12 +72,15 @@ export function App() {
       return;
     }
     setIsQuitting(true);
-    if (hasActiveSession) {
+    const { status } = useSessionStore.getState();
+    const currentlyActive =
+      status === "joining" || status === "joined" || status === "leaving";
+    if (currentlyActive) {
       await session.leave();
     }
     shutdownHub();
     renderer.destroy();
-  }, [renderer, session, hasActiveSession, isQuitting]);
+  }, [renderer, session, isQuitting]);
 
   const handleQuit = useCallback(() => {
     if (isQuitting) {

--- a/apps/tui/src/app.tsx
+++ b/apps/tui/src/app.tsx
@@ -171,11 +171,7 @@ export function App() {
     return (
       <WithSidebar>
         <ConfirmModal
-          message={
-            isQuitting
-              ? "Closing participant tunnel..."
-              : `${reasons.join(" and ")}. Are you sure you want to quit?`
-          }
+          message={`${reasons.join(" and ")}. Are you sure you want to quit?`}
           onCancel={handleCancelConfirm}
           onConfirm={handleConfirm}
           title="Confirm Quit"

--- a/apps/tui/src/components/participant-card.tsx
+++ b/apps/tui/src/components/participant-card.tsx
@@ -9,6 +9,17 @@ const statusColorMap: Record<ParticipantInfo["status"], string> = {
   offline: colors.muted,
 };
 
+function formatTunnelSeenAt(timestamp: number | null): string {
+  if (!timestamp) {
+    return "never";
+  }
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  return `${Math.floor(seconds / 60)}m ago`;
+}
+
 interface ParticipantCardProps {
   participant: ParticipantInfo;
   isProcessing?: boolean;
@@ -28,7 +39,13 @@ export function ParticipantCard({
   isOwnParticipant = false,
   ownHealthStatus,
 }: ParticipantCardProps) {
-  const status = isProcessing ? "busy" : participant.status;
+  const available = participant.connection.connected;
+  const status =
+    isProcessing && available
+      ? "busy"
+      : available
+        ? participant.status
+        : "offline";
   const indicator = statusIndicators[status];
   const statusColor = statusColorMap[status];
 
@@ -49,6 +66,9 @@ export function ParticipantCard({
     isProcessing && metrics
       ? `${metrics.tokensPerSecond?.toFixed(0) ?? "?"} tok/s ${metrics.latencyMs ?? "?"}ms`
       : "";
+  const tunnelSeenText = participant.connection.lastTunnelSeenAt
+    ? new Date(participant.connection.lastTunnelSeenAt).toLocaleTimeString()
+    : "never";
 
   return (
     <box
@@ -123,6 +143,13 @@ export function ParticipantCard({
               )}
             </box>
           )}
+          <text fg={participant.connection.connected ? colors.success : colors.error}>
+            Tunnel {participant.connection.connected ? "connected" : "disconnected"}
+          </text>
+          <text fg={colors.muted}>
+            Last tunnel seen:{" "}
+            {formatTunnelSeenAt(participant.connection.lastTunnelSeenAt)}
+          </text>
           {participant.config.hasInstructions && (
             <text fg={colors.muted}> Prompt defaults configured</text>
           )}

--- a/apps/tui/src/components/participant-card.tsx
+++ b/apps/tui/src/components/participant-card.tsx
@@ -66,9 +66,6 @@ export function ParticipantCard({
     isProcessing && metrics
       ? `${metrics.tokensPerSecond?.toFixed(0) ?? "?"} tok/s ${metrics.latencyMs ?? "?"}ms`
       : "";
-  const tunnelSeenText = participant.connection.lastTunnelSeenAt
-    ? new Date(participant.connection.lastTunnelSeenAt).toLocaleTimeString()
-    : "never";
 
   return (
     <box

--- a/apps/tui/src/hooks/queries/use-rooms-query.ts
+++ b/apps/tui/src/hooks/queries/use-rooms-query.ts
@@ -1,6 +1,5 @@
 import {
   type MachineSpecs,
-  type ParticipantAuthHeaders,
   type ParticipantCapabilities,
   ParticipantInfo,
   RoomSummary,
@@ -50,7 +49,6 @@ export interface JoinParticipantData {
   specs?: z.infer<typeof MachineSpecs>;
   config?: RuntimeConfig;
   capabilities?: ParticipantCapabilities;
-  authHeaders?: ParticipantAuthHeaders;
 }
 
 export interface CreateRoomData {

--- a/apps/tui/src/hooks/use-hub-api.ts
+++ b/apps/tui/src/hooks/use-hub-api.ts
@@ -1,6 +1,5 @@
 import {
   type MachineSpecs,
-  type ParticipantAuthHeaders,
   type ParticipantCapabilities,
   ParticipantInfo,
   RoomSummary,
@@ -57,7 +56,6 @@ export interface JoinParticipantData {
   specs?: z.infer<typeof MachineSpecs>;
   config?: RuntimeConfig;
   capabilities?: ParticipantCapabilities;
-  authHeaders?: ParticipantAuthHeaders;
 }
 
 export interface CreateRoomData {

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -1,9 +1,30 @@
-import { useCallback, useEffect, useRef } from "react";
+import {
+  createParticipantSession,
+  type ParticipantSession,
+} from "@gambi/core/participant-session";
+import { useCallback, useEffect } from "react";
+import { useAppStore } from "../store/app-store";
 import { useSessionStore } from "../store/session-store";
-import { type JoinParticipantData, useHubApi } from "./use-hub-api";
+import type {
+  MachineSpecs,
+  ParticipantAuthHeaders,
+  ParticipantCapabilities,
+  RuntimeConfig,
+} from "@gambi/core/types";
 
-const HEALTH_CHECK_INTERVAL = 10_000;
-const MAX_FAILURES = 3;
+let activeSession: ParticipantSession | null = null;
+
+export interface JoinParticipantData {
+  authHeaders?: ParticipantAuthHeaders;
+  capabilities?: ParticipantCapabilities;
+  config?: RuntimeConfig;
+  endpoint: string;
+  id: string;
+  model: string;
+  nickname: string;
+  password?: string;
+  specs?: MachineSpecs;
+}
 
 export interface UseParticipantSessionReturn {
   status: "idle" | "joining" | "joined" | "leaving" | "error";
@@ -15,7 +36,7 @@ export interface UseParticipantSessionReturn {
 }
 
 export function useParticipantSession(): UseParticipantSessionReturn {
-  const api = useHubApi();
+  const hubUrl = useAppStore((s) => s.hubUrl);
 
   // Read state from session store
   const status = useSessionStore((s) => s.status);
@@ -29,97 +50,91 @@ export function useParticipantSession(): UseParticipantSessionReturn {
   const setLeaving = useSessionStore((s) => s.setLeaving);
   const setError = useSessionStore((s) => s.setError);
   const reset = useSessionStore((s) => s.reset);
-  const recordHealthCheck = useSessionStore((s) => s.recordHealthCheck);
-
-  const healthIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const failureCountRef = useRef(0);
-
-  const stopHealthCheck = useCallback(() => {
-    if (healthIntervalRef.current) {
-      clearInterval(healthIntervalRef.current);
-      healthIntervalRef.current = null;
-    }
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = null;
-    }
-  }, []);
-
-  const startHealthCheck = useCallback(
-    (code: string, id: string) => {
-      stopHealthCheck();
-      failureCountRef.current = 0;
-      abortControllerRef.current = new AbortController();
-
-      healthIntervalRef.current = setInterval(async () => {
-        const result = await api.healthCheck(code, id);
-        const success = !result.error;
-
-        // Update global health status in session store
-        recordHealthCheck(success);
-
-        if (success) {
-          failureCountRef.current = 0;
-        } else {
-          failureCountRef.current += 1;
-          if (failureCountRef.current >= MAX_FAILURES) {
-            setError(
-              `Lost connection after ${MAX_FAILURES} failed health checks`
-            );
-            stopHealthCheck();
-          }
-        }
-      }, HEALTH_CHECK_INTERVAL);
-    },
-    [api, stopHealthCheck, recordHealthCheck, setError]
-  );
+  const setHealthStatus = useSessionStore((s) => s.setHealthStatus);
 
   const join = useCallback(
     async (code: string, data: JoinParticipantData): Promise<boolean> => {
-      setJoining(code);
-
-      const result = await api.joinRoom(code, data);
-
-      if (result.error) {
-        setError(result.error);
+      const currentStatus = useSessionStore.getState().status;
+      if (currentStatus === "joined" || currentStatus === "joining") {
+        setError("Leave the current participant session before joining again.");
         return false;
       }
 
-      if (result.data) {
-        setJoined(result.data.participant.id, code, {
-          nickname: data.nickname,
-          model: data.model,
-          endpoint: data.endpoint,
-        });
-        startHealthCheck(code, result.data.participant.id);
-        return true;
-      }
+      setJoining(code);
 
-      return false;
+      try {
+        const session = await createParticipantSession({
+          hubUrl,
+          roomCode: code,
+          participantId: data.id,
+          endpoint: data.endpoint,
+          model: data.model,
+          nickname: data.nickname,
+          password: data.password,
+          specs: data.specs,
+          config: data.config,
+          capabilities: data.capabilities,
+          authHeaders: data.authHeaders,
+        });
+
+        activeSession = session;
+        setJoined(session, session.participant.id, code, {
+          nickname: session.participant.nickname,
+          model: session.participant.model,
+          endpoint: session.participant.endpoint,
+        });
+        setHealthStatus("healthy");
+
+        session.waitUntilClosed().then((event) => {
+          if (activeSession !== session) {
+            return;
+          }
+          activeSession = null;
+          if (event.reason === "closed") {
+            reset();
+            return;
+          }
+          setError(
+            event.error?.message ??
+              (event.reason === "heartbeat_failed"
+                ? "Participant heartbeat failed."
+                : "Participant tunnel closed.")
+          );
+          setHealthStatus("unhealthy");
+        });
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setHealthStatus("unhealthy");
+        return false;
+      }
     },
-    [api, setJoining, setJoined, setError, startHealthCheck]
+    [hubUrl, setJoining, setJoined, setError, setHealthStatus, reset]
   );
 
   const leave = useCallback(async () => {
     setLeaving();
-    stopHealthCheck();
+    const session = activeSession;
+    activeSession = null;
 
-    // Get current values from store for API call
-    const currentState = useSessionStore.getState();
-    if (currentState.roomCode && currentState.participantId) {
-      await api.leaveRoom(currentState.roomCode, currentState.participantId);
+    if (session) {
+      await session.close();
     }
 
     reset();
-  }, [api, setLeaving, reset, stopHealthCheck]);
+  }, [setLeaving, reset]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      stopHealthCheck();
+      const session = activeSession;
+      activeSession = null;
+      if (session) {
+        void session.close();
+      }
     };
-  }, [stopHealthCheck]);
+  }, []);
 
   return {
     status,

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -50,7 +50,6 @@ export function useParticipantSession(): UseParticipantSessionReturn {
   const setLeaving = useSessionStore((s) => s.setLeaving);
   const setError = useSessionStore((s) => s.setError);
   const reset = useSessionStore((s) => s.reset);
-  const setHealthStatus = useSessionStore((s) => s.setHealthStatus);
 
   const join = useCallback(
     async (code: string, data: JoinParticipantData): Promise<boolean> => {
@@ -83,7 +82,6 @@ export function useParticipantSession(): UseParticipantSessionReturn {
           model: session.participant.model,
           endpoint: session.participant.endpoint,
         });
-        setHealthStatus("healthy");
 
         session
           .waitUntilClosed()
@@ -118,7 +116,7 @@ export function useParticipantSession(): UseParticipantSessionReturn {
         return false;
       }
     },
-    [hubUrl, setJoining, setJoined, setError, setHealthStatus, reset]
+    [hubUrl, setJoining, setJoined, setError, reset]
   );
 
   const leave = useCallback(async () => {
@@ -127,7 +125,11 @@ export function useParticipantSession(): UseParticipantSessionReturn {
     activeSession = null;
 
     if (session) {
-      await session.close();
+      try {
+        await session.close();
+      } catch {
+        // Always reset local state even if best-effort remote cleanup fails.
+      }
     }
 
     reset();

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -54,7 +54,11 @@ export function useParticipantSession(): UseParticipantSessionReturn {
   const join = useCallback(
     async (code: string, data: JoinParticipantData): Promise<boolean> => {
       const currentStatus = useSessionStore.getState().status;
-      if (currentStatus === "joined" || currentStatus === "joining") {
+      if (
+        currentStatus === "joined" ||
+        currentStatus === "joining" ||
+        currentStatus === "leaving"
+      ) {
         setError("Leave the current participant session before joining again.");
         return false;
       }
@@ -132,7 +136,9 @@ export function useParticipantSession(): UseParticipantSessionReturn {
       }
     }
 
-    reset();
+    if (activeSession === null) {
+      reset();
+    }
   }, [setLeaving, reset]);
 
   return {

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -2,7 +2,7 @@ import {
   createParticipantSession,
   type ParticipantSession,
 } from "@gambi/core/participant-session";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { useAppStore } from "../store/app-store";
 import { useSessionStore } from "../store/session-store";
 import type {
@@ -124,17 +124,6 @@ export function useParticipantSession(): UseParticipantSessionReturn {
 
     reset();
   }, [setLeaving, reset]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      const session = activeSession;
-      activeSession = null;
-      if (session) {
-        void session.close();
-      }
-    };
-  }, []);
 
   return {
     status,

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -77,7 +77,7 @@ export function useParticipantSession(): UseParticipantSessionReturn {
         });
 
         activeSession = session;
-        setJoined(session, session.participant.id, code, {
+        setJoined(session.participant.id, code, {
           nickname: session.participant.nickname,
           model: session.participant.model,
           endpoint: session.participant.endpoint,

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -59,7 +59,6 @@ export function useParticipantSession(): UseParticipantSessionReturn {
         currentStatus === "joining" ||
         currentStatus === "leaving"
       ) {
-        setError("Leave the current participant session before joining again.");
         return false;
       }
 

--- a/apps/tui/src/hooks/use-participant-session.ts
+++ b/apps/tui/src/hooks/use-participant-session.ts
@@ -85,28 +85,36 @@ export function useParticipantSession(): UseParticipantSessionReturn {
         });
         setHealthStatus("healthy");
 
-        session.waitUntilClosed().then((event) => {
-          if (activeSession !== session) {
-            return;
-          }
-          activeSession = null;
-          if (event.reason === "closed") {
-            reset();
-            return;
-          }
-          setError(
-            event.error?.message ??
-              (event.reason === "heartbeat_failed"
-                ? "Participant heartbeat failed."
-                : "Participant tunnel closed.")
-          );
-          setHealthStatus("unhealthy");
-        });
+        session
+          .waitUntilClosed()
+          .then((event) => {
+            if (activeSession !== session) {
+              return;
+            }
+            activeSession = null;
+            if (event.reason === "closed") {
+              reset();
+              return;
+            }
+            setError(
+              event.error?.message ??
+                (event.reason === "heartbeat_failed"
+                  ? "Participant heartbeat failed."
+                  : "Participant tunnel closed.")
+            );
+          })
+          .catch((err: unknown) => {
+            if (activeSession !== session) {
+              return;
+            }
+            activeSession = null;
+            const message = err instanceof Error ? err.message : String(err);
+            setError(message);
+          });
         return true;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setError(message);
-        setHealthStatus("unhealthy");
         return false;
       }
     },

--- a/apps/tui/src/hooks/use-room.ts
+++ b/apps/tui/src/hooks/use-room.ts
@@ -11,6 +11,7 @@ import {
   SSEParticipantJoinedEvent,
   SSEParticipantLeftEvent,
   SSEParticipantOfflineEvent,
+  SSEParticipantUpdatedEvent,
   SSERoomCreatedEvent,
 } from "../types";
 import { useSSE } from "./use-sse";
@@ -126,6 +127,16 @@ export function useRoom(options: UseRoomOptions): UseRoomReturn {
     },
     [addLog]
   );
+
+  const handleParticipantUpdated = useCallback((data: unknown) => {
+    const parsed = SSEParticipantUpdatedEvent.safeParse(data);
+    if (parsed.success) {
+      const participant = parsed.data;
+      setParticipants((prev) =>
+        new Map(prev).set(participant.id, participant)
+      );
+    }
+  }, []);
 
   const handleParticipantLeft = useCallback(
     (data: unknown) => {
@@ -260,6 +271,7 @@ export function useRoom(options: UseRoomOptions): UseRoomReturn {
         connected: handleConnected,
         "room.created": handleRoomCreated,
         "participant.joined": handleParticipantJoined,
+        "participant.updated": handleParticipantUpdated,
         "participant.left": handleParticipantLeft,
         "participant.offline": handleParticipantOffline,
         "llm.request": handleLlmRequest,
@@ -272,6 +284,7 @@ export function useRoom(options: UseRoomOptions): UseRoomReturn {
       handleConnected,
       handleRoomCreated,
       handleParticipantJoined,
+      handleParticipantUpdated,
       handleParticipantLeft,
       handleParticipantOffline,
       handleLlmRequest,

--- a/apps/tui/src/hooks/use-rooms.test.ts
+++ b/apps/tui/src/hooks/use-rooms.test.ts
@@ -12,6 +12,7 @@ import {
   handleParticipantJoinedEvent,
   handleParticipantLeftEvent,
   handleParticipantOfflineEvent,
+  handleParticipantUpdatedEvent,
   handleRoomCreatedEvent,
   unwrapSSEEventPayload,
 } from "./use-rooms";
@@ -94,18 +95,7 @@ describe("handleRoomCreatedEvent", () => {
 describe("handleParticipantJoinedEvent", () => {
   test("adds participant to room", () => {
     const room = createRoom();
-    const data = {
-      id: "p1",
-      nickname: "Bot1",
-      model: "llama3",
-      endpoint: "http://localhost:11434",
-      status: "online",
-      joinedAt: Date.now(),
-      lastSeen: Date.now(),
-      updatedAt: Date.now(),
-      specs: {},
-      config: {},
-    };
+    const data = createParticipant("p1", "Bot1");
     const result = handleParticipantJoinedEvent(room, data);
 
     expect(result.room.participants.has("p1")).toBe(true);
@@ -114,18 +104,7 @@ describe("handleParticipantJoinedEvent", () => {
 
   test("creates log entry with type join", () => {
     const room = createRoom();
-    const data = {
-      id: "p1",
-      nickname: "Bot1",
-      model: "llama3",
-      endpoint: "http://localhost:11434",
-      status: "online",
-      joinedAt: Date.now(),
-      lastSeen: Date.now(),
-      updatedAt: Date.now(),
-      specs: {},
-      config: {},
-    };
+    const data = createParticipant("p1", "Bot1");
     const result = handleParticipantJoinedEvent(room, data);
 
     expect(result.log).toBeDefined();
@@ -140,6 +119,36 @@ describe("handleParticipantJoinedEvent", () => {
     const result = handleParticipantJoinedEvent(room, { invalid: true });
 
     expect(result.room.participants.size).toBe(0);
+    expect(result.log).toBeUndefined();
+  });
+});
+
+describe("handleParticipantUpdatedEvent", () => {
+  test("updates participant in room", () => {
+    const participants = new Map();
+    participants.set("p1", createParticipant("p1", "Bot1"));
+    const room = createRoom({ participants });
+    const updated = createParticipant("p1", "Bot1-renamed", {
+      connection: {
+        kind: "tunnel",
+        connected: false,
+        lastTunnelSeenAt: null,
+      },
+      status: "offline",
+    });
+
+    const result = handleParticipantUpdatedEvent(room, updated);
+
+    expect(result.room.participants.get("p1")?.nickname).toBe("Bot1-renamed");
+    expect(result.room.participants.get("p1")?.connection.connected).toBe(false);
+    expect(result.log).toBeUndefined();
+  });
+
+  test("returns unchanged room on invalid data", () => {
+    const room = createRoomWithParticipants(1);
+    const result = handleParticipantUpdatedEvent(room, { invalid: true });
+
+    expect(result.room.participants.get("p1")?.nickname).toBe("Bot1");
     expect(result.log).toBeUndefined();
   });
 });

--- a/apps/tui/src/hooks/use-rooms.ts
+++ b/apps/tui/src/hooks/use-rooms.ts
@@ -16,6 +16,7 @@ import {
   SSEParticipantJoinedEvent,
   SSEParticipantLeftEvent,
   SSEParticipantOfflineEvent,
+  SSEParticipantUpdatedEvent,
   SSERoomCreatedEvent,
 } from "../types";
 
@@ -126,6 +127,20 @@ export function handleParticipantJoinedEvent(
       message: `${participant.nickname} joined`,
     },
   };
+}
+
+export function handleParticipantUpdatedEvent(
+  room: RoomState,
+  data: unknown
+): EventResult {
+  const parsed = SSEParticipantUpdatedEvent.safeParse(data);
+  if (!parsed.success) {
+    return { room };
+  }
+  const participant = parsed.data;
+  const participants = new Map(room.participants);
+  participants.set(participant.id, participant);
+  return { room: { ...room, participants } };
 }
 
 export function handleParticipantLeftEvent(
@@ -366,6 +381,7 @@ export function useRooms(): UseRoomsReturn {
           connected: (r) => handleConnectedEvent(r),
           "room.created": (r, d) => handleRoomCreatedEvent(r, code, d),
           "participant.joined": handleParticipantJoinedEvent,
+          "participant.updated": handleParticipantUpdatedEvent,
           "participant.left": handleParticipantLeftEvent,
           "participant.offline": handleParticipantOfflineEvent,
           "llm.request": handleLlmRequestEvent,
@@ -393,6 +409,7 @@ export function useRooms(): UseRoomsReturn {
       // Invalidate participant queries when relevant events occur
       if (
         event === "participant.joined" ||
+        event === "participant.updated" ||
         event === "participant.left" ||
         event === "participant.offline"
       ) {

--- a/apps/tui/src/index.tsx
+++ b/apps/tui/src/index.tsx
@@ -2,6 +2,7 @@ import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./app";
+import { useAppStore } from "./store/app-store";
 
 export interface StartTUIOptions {
   hubUrl: string;
@@ -18,10 +19,11 @@ const queryClient = new QueryClient({
 });
 
 export async function startTUI(options: StartTUIOptions) {
+  useAppStore.getState().setHubUrl(options.hubUrl);
   const renderer = await createCliRenderer();
   createRoot(renderer).render(
     <QueryClientProvider client={queryClient}>
-      <App hubUrl={options.hubUrl} />
+      <App />
     </QueryClientProvider>
   );
 }

--- a/apps/tui/src/screens/join-room.tsx
+++ b/apps/tui/src/screens/join-room.tsx
@@ -412,6 +412,7 @@ export function JoinRoom({
   // Get persisted endpoint from store
   const lastLlmEndpoint = useAppStore((s) => s.lastLlmEndpoint);
   const setLastLlmEndpoint = useAppStore((s) => s.setLastLlmEndpoint);
+  const participantId = useAppStore((s) => s.participantId);
 
   // React Hook Form with Zod validation
   const {
@@ -462,6 +463,14 @@ export function JoinRoom({
 
   // Form submission
   const handleJoin = useCallback(async () => {
+    if (session.status === "joining") {
+      return;
+    }
+
+    if (session.status === "joined") {
+      return;
+    }
+
     if (authHeaderResolution.error) {
       return;
     }
@@ -473,7 +482,7 @@ export function JoinRoom({
 
     const endpointTrimmed = formValues.endpoint.trim();
     const success = await session.join(formValues.roomCode.trim(), {
-      id: crypto.randomUUID(),
+      id: participantId,
       nickname: formValues.nickname.trim() || generateNickname(),
       model: formValues.model.trim(),
       endpoint: endpointTrimmed,
@@ -494,6 +503,7 @@ export function JoinRoom({
     authHeaderResolution.authHeaders,
     authHeaderResolution.error,
     formValues,
+    participantId,
     specs,
     session,
     onNavigate,
@@ -600,6 +610,9 @@ export function JoinRoom({
     (key) => {
       if (session.status === "joined") {
         handleJoinedKey(key.name ?? "");
+        return;
+      }
+      if (session.status === "joining") {
         return;
       }
       if (key.name === "escape") {
@@ -719,7 +732,7 @@ export function JoinRoom({
         )}
         {session.error && <text fg={colors.error}>Error: {session.error}</text>}
         {session.status === "joining" && (
-          <text fg={colors.muted}>Joining room...</text>
+          <text fg={colors.muted}>Joining room and opening tunnel...</text>
         )}
       </box>
 
@@ -737,7 +750,10 @@ export function JoinRoom({
                 { key: "d", description: "Remove last header" },
               ]
             : []),
-          { key: "Enter", description: "Join" },
+          {
+            key: "Enter",
+            description: session.status === "joining" ? "Joining..." : "Join",
+          },
         ]}
       />
     </box>

--- a/apps/tui/src/store/app-store.ts
+++ b/apps/tui/src/store/app-store.ts
@@ -10,6 +10,10 @@ interface AppState {
   hubUrl: string;
   setHubUrl: (url: string) => void;
 
+  // Stable participant ID for retry-safe tunnel registrations
+  participantId: string;
+  setParticipantId: (id: string) => void;
+
   // Last used LLM endpoint (for join form)
   lastLlmEndpoint: string;
   setLastLlmEndpoint: (endpoint: string) => void;
@@ -23,12 +27,23 @@ interface AppState {
 
 // Load initial values from config
 const initialConfig = loadConfig();
+const initialParticipantId =
+  initialConfig.participantId ?? crypto.randomUUID();
+if (!initialConfig.participantId) {
+  updateConfig({ participantId: initialParticipantId });
+}
 
 export const useAppStore = create<AppState>((set, get) => ({
   hubUrl: initialConfig.hubUrl ?? "http://localhost:3000",
   setHubUrl: (hubUrl) => {
     set({ hubUrl });
     updateConfig({ hubUrl });
+  },
+
+  participantId: initialParticipantId,
+  setParticipantId: (participantId) => {
+    set({ participantId });
+    updateConfig({ participantId });
   },
 
   lastLlmEndpoint: initialConfig.llmEndpoint ?? "http://localhost:11434",

--- a/apps/tui/src/store/session-store.test.ts
+++ b/apps/tui/src/store/session-store.test.ts
@@ -1,5 +1,31 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import type { ParticipantSession } from "@gambi/core/participant-session";
 import { useSessionStore } from "./session-store";
+
+const mockSession = {
+  close: async () => ({ reason: "closed" as const }),
+  participant: {
+    id: "p1",
+    nickname: "Bot1",
+    model: "llama3",
+    endpoint: "http://localhost:11434",
+    status: "online",
+    joinedAt: Date.now(),
+    lastSeen: Date.now(),
+    updatedAt: Date.now(),
+    specs: {},
+    config: { hasInstructions: false },
+    capabilities: { openResponses: "unknown", chatCompletions: "unknown" },
+    connection: {
+      kind: "tunnel",
+      connected: true,
+      lastTunnelSeenAt: Date.now(),
+    },
+  },
+  roomId: "room-1",
+  tunnel: { url: "ws://localhost:3000/tunnel", token: "token" },
+  waitUntilClosed: async () => ({ reason: "closed" as const }),
+} satisfies ParticipantSession;
 
 afterEach(() => {
   // Reset store state between tests
@@ -30,13 +56,14 @@ describe("session-store", () => {
   test("setJoined transitions correctly", () => {
     const { setJoined } = useSessionStore.getState();
 
-    setJoined("p1", "ABC123");
+    setJoined(mockSession, "p1", "ABC123");
 
     const state = useSessionStore.getState();
     expect(state.status).toBe("joined");
     expect(state.participantId).toBe("p1");
     expect(state.roomCode).toBe("ABC123");
     expect(state.error).toBeNull();
+    expect(state.session).toBe(mockSession);
   });
 
   test("setError preserves roomCode", () => {
@@ -54,7 +81,7 @@ describe("session-store", () => {
   test("reset clears all state", () => {
     const { setJoined, reset } = useSessionStore.getState();
 
-    setJoined("p1", "ABC123");
+    setJoined(mockSession, "p1", "ABC123");
     reset();
 
     const state = useSessionStore.getState();
@@ -62,6 +89,7 @@ describe("session-store", () => {
     expect(state.participantId).toBeNull();
     expect(state.roomCode).toBeNull();
     expect(state.error).toBeNull();
+    expect(state.session).toBeNull();
   });
 
   test("setJoining clears previous error", () => {

--- a/apps/tui/src/store/session-store.test.ts
+++ b/apps/tui/src/store/session-store.test.ts
@@ -1,31 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { ParticipantSession } from "@gambi/core/participant-session";
 import { useSessionStore } from "./session-store";
-
-const mockSession = {
-  close: async () => ({ reason: "closed" as const }),
-  participant: {
-    id: "p1",
-    nickname: "Bot1",
-    model: "llama3",
-    endpoint: "http://localhost:11434",
-    status: "online",
-    joinedAt: Date.now(),
-    lastSeen: Date.now(),
-    updatedAt: Date.now(),
-    specs: {},
-    config: { hasInstructions: false },
-    capabilities: { openResponses: "unknown", chatCompletions: "unknown" },
-    connection: {
-      kind: "tunnel",
-      connected: true,
-      lastTunnelSeenAt: Date.now(),
-    },
-  },
-  roomId: "room-1",
-  tunnel: { url: "ws://localhost:3000/tunnel", token: "token" },
-  waitUntilClosed: async () => ({ reason: "closed" as const }),
-} satisfies ParticipantSession;
 
 afterEach(() => {
   // Reset store state between tests
@@ -56,14 +30,13 @@ describe("session-store", () => {
   test("setJoined transitions correctly", () => {
     const { setJoined } = useSessionStore.getState();
 
-    setJoined(mockSession, "p1", "ABC123");
+    setJoined("p1", "ABC123");
 
     const state = useSessionStore.getState();
     expect(state.status).toBe("joined");
     expect(state.participantId).toBe("p1");
     expect(state.roomCode).toBe("ABC123");
     expect(state.error).toBeNull();
-    expect(state.session).toBe(mockSession);
   });
 
   test("setError preserves roomCode", () => {
@@ -81,7 +54,7 @@ describe("session-store", () => {
   test("reset clears all state", () => {
     const { setJoined, reset } = useSessionStore.getState();
 
-    setJoined(mockSession, "p1", "ABC123");
+    setJoined("p1", "ABC123");
     reset();
 
     const state = useSessionStore.getState();
@@ -89,7 +62,6 @@ describe("session-store", () => {
     expect(state.participantId).toBeNull();
     expect(state.roomCode).toBeNull();
     expect(state.error).toBeNull();
-    expect(state.session).toBeNull();
   });
 
   test("setJoining clears previous error", () => {

--- a/apps/tui/src/store/session-store.ts
+++ b/apps/tui/src/store/session-store.ts
@@ -12,7 +12,6 @@ interface SessionState {
   model: string | null;
   endpoint: string | null;
   error: string | null;
-  closeReason: string | null;
 
   // Health tracking
   healthStatus: HealthStatus;
@@ -26,11 +25,8 @@ interface SessionState {
     details?: { nickname?: string; model?: string; endpoint?: string }
   ) => void;
   setLeaving: () => void;
-  setError: (error: string, closeReason?: string) => void;
+  setError: (error: string) => void;
   reset: () => void;
-
-  // Health actions
-  setHealthStatus: (status: HealthStatus) => void;
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -42,7 +38,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   model: null,
   endpoint: null,
   error: null,
-  closeReason: null,
 
   // Initial health state
   healthStatus: "healthy",
@@ -54,7 +49,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       status: "joining",
       roomCode,
       error: null,
-      closeReason: null,
       healthStatus: "degraded",
       lastHealthCheck: null,
     }),
@@ -68,18 +62,16 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       model: details?.model ?? null,
       endpoint: details?.endpoint ?? null,
       error: null,
-      closeReason: null,
       healthStatus: "healthy",
       lastHealthCheck: new Date(),
     }),
 
   setLeaving: () => set({ status: "leaving", healthStatus: "degraded" }),
 
-  setError: (error, closeReason) =>
+  setError: (error) =>
     set({
       status: "error",
       error,
-      closeReason: closeReason ?? null,
       healthStatus: "unhealthy",
     }),
 
@@ -92,11 +84,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       model: null,
       endpoint: null,
       error: null,
-      closeReason: null,
       healthStatus: "healthy",
       lastHealthCheck: null,
     }),
-
-  // Health actions
-  setHealthStatus: (healthStatus) => set({ healthStatus }),
 }));

--- a/apps/tui/src/store/session-store.ts
+++ b/apps/tui/src/store/session-store.ts
@@ -1,3 +1,4 @@
+import type { ParticipantSession } from "@gambi/core/participant-session";
 import { create } from "zustand";
 
 type SessionStatus = "idle" | "joining" | "joined" | "leaving" | "error";
@@ -12,30 +13,29 @@ interface SessionState {
   model: string | null;
   endpoint: string | null;
   error: string | null;
+  closeReason: string | null;
+  session: ParticipantSession | null;
 
   // Health tracking
   healthStatus: HealthStatus;
   lastHealthCheck: Date | null;
-  consecutiveFailures: number;
 
   // Connection actions
   setJoining: (roomCode: string) => void;
   setJoined: (
+    session: ParticipantSession,
     participantId: string,
     roomCode: string,
     details?: { nickname?: string; model?: string; endpoint?: string }
   ) => void;
   setLeaving: () => void;
-  setError: (error: string) => void;
+  setError: (error: string, closeReason?: string) => void;
   reset: () => void;
 
   // Health actions
   setHealthStatus: (status: HealthStatus) => void;
-  recordHealthCheck: (success: boolean) => void;
+  markHealthy: () => void;
 }
-
-const DEGRADED_THRESHOLD = 1;
-const UNHEALTHY_THRESHOLD = 3;
 
 export const useSessionStore = create<SessionState>((set, get) => ({
   // Initial connection state
@@ -46,16 +46,25 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   model: null,
   endpoint: null,
   error: null,
+  closeReason: null,
+  session: null,
 
   // Initial health state
   healthStatus: "healthy",
   lastHealthCheck: null,
-  consecutiveFailures: 0,
 
   // Connection actions
-  setJoining: (roomCode) => set({ status: "joining", roomCode, error: null }),
+  setJoining: (roomCode) =>
+    set({
+      status: "joining",
+      roomCode,
+      error: null,
+      closeReason: null,
+      healthStatus: "degraded",
+      lastHealthCheck: null,
+    }),
 
-  setJoined: (participantId, roomCode, details) =>
+  setJoined: (session, participantId, roomCode, details) =>
     set({
       status: "joined",
       participantId,
@@ -64,13 +73,22 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       model: details?.model ?? null,
       endpoint: details?.endpoint ?? null,
       error: null,
+      closeReason: null,
+      session,
       healthStatus: "healthy",
-      consecutiveFailures: 0,
+      lastHealthCheck: new Date(),
     }),
 
-  setLeaving: () => set({ status: "leaving" }),
+  setLeaving: () => set({ status: "leaving", healthStatus: "degraded" }),
 
-  setError: (error) => set({ status: "error", error }),
+  setError: (error, closeReason) =>
+    set({
+      status: "error",
+      error,
+      closeReason: closeReason ?? null,
+      healthStatus: "unhealthy",
+      session: null,
+    }),
 
   reset: () =>
     set({
@@ -81,37 +99,18 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       model: null,
       endpoint: null,
       error: null,
+      closeReason: null,
+      session: null,
       healthStatus: "healthy",
       lastHealthCheck: null,
-      consecutiveFailures: 0,
     }),
 
   // Health actions
   setHealthStatus: (healthStatus) => set({ healthStatus }),
 
-  recordHealthCheck: (success) => {
-    const current = get();
-
-    if (success) {
-      set({
-        healthStatus: "healthy",
-        lastHealthCheck: new Date(),
-        consecutiveFailures: 0,
-      });
-    } else {
-      const failures = current.consecutiveFailures + 1;
-      let healthStatus: HealthStatus = "healthy";
-
-      if (failures >= UNHEALTHY_THRESHOLD) {
-        healthStatus = "unhealthy";
-      } else if (failures >= DEGRADED_THRESHOLD) {
-        healthStatus = "degraded";
-      }
-
-      set({
-        healthStatus,
-        consecutiveFailures: failures,
-      });
-    }
-  },
+  markHealthy: () =>
+    set({
+      healthStatus: "healthy",
+      lastHealthCheck: new Date(),
+    }),
 }));

--- a/apps/tui/src/store/session-store.ts
+++ b/apps/tui/src/store/session-store.ts
@@ -1,4 +1,3 @@
-import type { ParticipantSession } from "@gambi/core/participant-session";
 import { create } from "zustand";
 
 type SessionStatus = "idle" | "joining" | "joined" | "leaving" | "error";
@@ -14,7 +13,6 @@ interface SessionState {
   endpoint: string | null;
   error: string | null;
   closeReason: string | null;
-  session: ParticipantSession | null;
 
   // Health tracking
   healthStatus: HealthStatus;
@@ -23,7 +21,6 @@ interface SessionState {
   // Connection actions
   setJoining: (roomCode: string) => void;
   setJoined: (
-    session: ParticipantSession,
     participantId: string,
     roomCode: string,
     details?: { nickname?: string; model?: string; endpoint?: string }
@@ -46,7 +43,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   endpoint: null,
   error: null,
   closeReason: null,
-  session: null,
 
   // Initial health state
   healthStatus: "healthy",
@@ -63,7 +59,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       lastHealthCheck: null,
     }),
 
-  setJoined: (session, participantId, roomCode, details) =>
+  setJoined: (participantId, roomCode, details) =>
     set({
       status: "joined",
       participantId,
@@ -73,7 +69,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       endpoint: details?.endpoint ?? null,
       error: null,
       closeReason: null,
-      session,
       healthStatus: "healthy",
       lastHealthCheck: new Date(),
     }),
@@ -86,7 +81,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       error,
       closeReason: closeReason ?? null,
       healthStatus: "unhealthy",
-      session: null,
     }),
 
   reset: () =>
@@ -99,7 +93,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       endpoint: null,
       error: null,
       closeReason: null,
-      session: null,
       healthStatus: "healthy",
       lastHealthCheck: null,
     }),

--- a/apps/tui/src/store/session-store.ts
+++ b/apps/tui/src/store/session-store.ts
@@ -34,7 +34,6 @@ interface SessionState {
 
   // Health actions
   setHealthStatus: (status: HealthStatus) => void;
-  markHealthy: () => void;
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -107,10 +106,4 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   // Health actions
   setHealthStatus: (healthStatus) => set({ healthStatus }),
-
-  markHealthy: () =>
-    set({
-      healthStatus: "healthy",
-      lastHealthCheck: new Date(),
-    }),
 }));

--- a/apps/tui/src/types.test.ts
+++ b/apps/tui/src/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { ActivityLogEntry, ActivityLogType, LogMetrics } from "./types";
+import {
+  ActivityLogEntry,
+  ActivityLogType,
+  LogMetrics,
+  SSEParticipantUpdatedEvent,
+} from "./types";
 
 describe("ActivityLogType", () => {
   test("accepts all valid log types", () => {
@@ -128,5 +133,35 @@ describe("ActivityLogEntry", () => {
 
     const result = ActivityLogEntry.safeParse(entry);
     expect(result.success).toBe(false);
+  });
+});
+
+describe("SSEParticipantUpdatedEvent", () => {
+  test("validates participant update payload with tunnel connection", () => {
+    const now = Date.now();
+    const result = SSEParticipantUpdatedEvent.safeParse({
+      id: "p1",
+      nickname: "Bot1",
+      model: "llama3",
+      endpoint: "http://localhost:11434",
+      status: "online",
+      joinedAt: now,
+      lastSeen: now,
+      updatedAt: now,
+      specs: {},
+      config: { hasInstructions: false },
+      capabilities: {
+        openResponses: "supported",
+        chatCompletions: "unknown",
+      },
+      connection: {
+        kind: "tunnel",
+        connected: true,
+        lastTunnelSeenAt: now,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.connection.connected).toBe(true);
   });
 });

--- a/apps/tui/src/types.ts
+++ b/apps/tui/src/types.ts
@@ -94,17 +94,17 @@ export interface SSEEvent {
   data: unknown;
 }
 
-// Design system colors
+// Design system colors tuned for both light and dark terminal backgrounds.
 export const colors = {
-  primary: "#00FFFF", // Cyan - headers, focus, interactive
-  success: "#00FF00", // Green - online, success, joins
-  warning: "#FFAA00", // Amber - busy, processing, requests
-  error: "#FF5555", // Red - offline, errors
-  muted: "#666666", // Gray - secondary text, disabled
-  metrics: "#FF79C6", // Pink - tok/s, latency numbers
-  text: "#FFFFFF", // White - primary text
-  surface: "#333333", // Dark gray - backgrounds, selected items
-  accent: "#AA55FF", // Purple - accent/highlight
+  primary: "#2563EB", // Blue - headers, focus, interactive
+  success: "#15803D", // Green - online, success, joins
+  warning: "#B45309", // Amber - busy, processing, requests
+  error: "#DC2626", // Red - offline, errors
+  muted: "#737373", // Gray - secondary text, disabled
+  metrics: "#BE185D", // Rose - tok/s, latency numbers
+  text: "#6B7280", // Neutral - primary text
+  surface: "#D1D5DB", // Gray - focused/selected backgrounds
+  accent: "#7C3AED", // Violet - accent/highlight
 } as const;
 
 // Status indicators

--- a/apps/tui/src/types.ts
+++ b/apps/tui/src/types.ts
@@ -64,6 +64,8 @@ export const SSERoomCreatedEvent = z.object({
 
 export const SSEParticipantJoinedEvent = ParticipantInfoSchema;
 
+export const SSEParticipantUpdatedEvent = ParticipantInfoSchema;
+
 export const SSEParticipantLeftEvent = z.object({
   participantId: z.string(),
 });

--- a/apps/tui/src/types.ts
+++ b/apps/tui/src/types.ts
@@ -102,7 +102,7 @@ export const colors = {
   error: "#DC2626", // Red - offline, errors
   muted: "#737373", // Gray - secondary text, disabled
   metrics: "#BE185D", // Rose - tok/s, latency numbers
-  text: "#6B7280", // Neutral - primary text
+  text: "#D1D5DB", // Light neutral - primary text on dark terminals
   surface: "#D1D5DB", // Gray - focused/selected backgrounds
   accent: "#7C3AED", // Violet - accent/highlight
 } as const;

--- a/apps/tui/src/types.ts
+++ b/apps/tui/src/types.ts
@@ -103,7 +103,7 @@ export const colors = {
   muted: "#737373", // Gray - secondary text, disabled
   metrics: "#BE185D", // Rose - tok/s, latency numbers
   text: "#D1D5DB", // Light neutral - primary text on dark terminals
-  surface: "#D1D5DB", // Gray - focused/selected backgrounds
+  surface: "#334155", // Slate - focused/selected backgrounds
   accent: "#7C3AED", // Violet - accent/highlight
 } as const;
 

--- a/apps/tui/src/utils/config.ts
+++ b/apps/tui/src/utils/config.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 export interface UserConfig {
   hubUrl?: string;
   llmEndpoint?: string;
+  participantId?: string;
 }
 
 const CONFIG_PATH = join(homedir(), ".gambi", "config.json");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updates the TUI participant join flow to run the canonical tunnel-first `createParticipantSession()` runtime in-process.
- Persists a stable TUI participant id for retry-safe registration.
- Reflects tunnel session health in TUI state, blocks duplicate joins, and performs async session cleanup before quit.
- Adds participant `connection` visibility and `participant.updated` SSE handling.
- Keeps the tunnel session alive across Join -> Monitor navigation; cleanup now happens through explicit leave/quit.
- Initializes the TUI hub URL before rendering instead of via `useEffect`.
- Tunes the shared TUI palette away from neon cyan/white toward colors that read better on light and dark terminal backgrounds.
- Handles unexpected `waitUntilClosed()` rejection, hardens `leave()` cleanup if `close()` rejects, and removes dead/redundant session state code.
- Separates primary text and selected/focused surface colors to avoid invisible focused fields.
- Guards leave/join races so older closes or duplicate joins cannot clobber a live session, and reads fresh session state during quit.

## Walkthrough

[tui_tunnel_join_and_inference.mp4](https://cursor.com/agents/bc-0680db74-6d18-4550-9aa7-d2c8e62714a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_tunnel_join_and_inference.mp4)

[TUI palette main menu](https://cursor.com/agents/bc-0680db74-6d18-4550-9aa7-d2c8e62714a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_palette_main_menu.png)
[TUI palette monitor](https://cursor.com/agents/bc-0680db74-6d18-4550-9aa7-d2c8e62714a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_palette_monitor.png)

## Validation

- `bun run --cwd apps/tui check-types`
- `bun test apps/tui/src`
- Manual TUI tunnel walkthrough with fake OpenAI-compatible provider and hub inference through `/rooms/:code/v1/chat/completions`.
- Manual visual check of main menu and monitor palette on the visible light terminal background.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0680db74-6d18-4550-9aa7-d2c8e62714a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0680db74-6d18-4550-9aa7-d2c8e62714a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

